### PR TITLE
Implement timetable screenshot upload intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,5 @@ python3 -m unittest discover -s tests
 - The OCR worker now emits a payload shape that the Spring Boot backend can consume.
 - The frontend is currently a polished shell for the main tabs and shared design system.
 - The home flow now reflects the AIT reality that a fresh timetable arrives every Saturday for the next week.
-- Timetable screenshot upload and full backend-worker wiring is the next backend integration step.
+- The Home upload action now opens the native image picker and creates a real timetable upload batch through Spring Boot.
+- Full parser wiring still needs the backend worker step that turns the stored screenshot into parsed timetable entries.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "~54.0.33",
+        "expo-image-picker": "~17.0.10",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5"
@@ -3760,6 +3761,27 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.10.tgz",
+      "integrity": "sha512-a2xrowp2trmvXyUWgX3O6Q2rZaa2C59AqivKI7+bm+wLvMfTEbZgldLX4rEJJhM8xtmEDTNU+lzjtObwzBRGaw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "~54.0.33",
+    "expo-image-picker": "~17.0.10",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5"

--- a/app/src/features/home/timetable-intelligence.ts
+++ b/app/src/features/home/timetable-intelligence.ts
@@ -125,14 +125,16 @@ export function getScheduleInsight(entries: ClassEntry[], focusedDate: Date, now
 
 export function getRefreshInsight(
   today: Date,
-  uploadState: 'idle' | 'uploading' | 'updated',
+  uploadState: 'idle' | 'uploading' | 'updated' | 'error',
   lastUploadMeta: UploadMeta | null
 ): RefreshInsight {
   if (uploadState === 'updated') {
     return {
       state: 'updated',
       title: 'Timetable updated',
-      body: 'Your latest timetable upload is staged and ready for parsing.',
+      body: lastUploadMeta?.imageName
+        ? `${lastUploadMeta.imageName} is uploaded and ready for parsing.`
+        : 'Your latest timetable upload is staged and ready for parsing.',
       urgency: 'low',
     };
   }
@@ -144,7 +146,7 @@ export function getRefreshInsight(
       title: refreshDue ? 'Week ready for a fresh upload' : 'Week ready',
       body: `Last staged from ${formatUploadSource(lastUploadMeta.source)} on ${formatShortDateTime(
         lastUploadMeta.timestamp
-      )}.`,
+      )}${lastUploadMeta.imageName ? ` • ${lastUploadMeta.imageName}` : ''}.`,
       urgency: refreshDue ? 'high' : 'low',
     };
   }

--- a/app/src/features/home/timetable-types.ts
+++ b/app/src/features/home/timetable-types.ts
@@ -20,6 +20,9 @@ export type CalendarTag = {
 export type UploadSource = 'share' | 'mail' | 'photos';
 
 export type UploadMeta = {
+  batchId: number;
   source: UploadSource;
   timestamp: string;
+  imageName?: string;
+  status?: string;
 };

--- a/app/src/lib/timetable-api.ts
+++ b/app/src/lib/timetable-api.ts
@@ -1,0 +1,63 @@
+import { API_BASE_URL, extractErrorMessage, getNetworkMessage } from './http-client';
+
+export type TimetableUploadResult =
+  | {
+      ok: true;
+      batchId: number;
+      sourceImageName?: string;
+      status: string;
+      createdAt?: string;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+export async function uploadTimetableScreenshot(payload: {
+  uri: string;
+  name: string;
+  mimeType: string;
+  sourceHint: string;
+  sourceNotes?: string;
+}): Promise<TimetableUploadResult> {
+  try {
+    const formData = new FormData();
+    formData.append('file', {
+      uri: payload.uri,
+      name: payload.name,
+      type: payload.mimeType,
+    } as unknown as Blob);
+    formData.append('sourceHint', payload.sourceHint);
+    if (payload.sourceNotes) {
+      formData.append('sourceNotes', payload.sourceNotes);
+    }
+
+    const response = await fetch(`${API_BASE_URL}/timetable-batches/uploads`, {
+      method: 'POST',
+      body: formData,
+    });
+
+    const rawText = await response.text();
+    const data = rawText ? JSON.parse(rawText) : {};
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        message: extractErrorMessage(data, 'Timetable upload failed.'),
+      };
+    }
+
+    return {
+      ok: true,
+      batchId: data.id,
+      sourceImageName: data.sourceImageName,
+      status: data.status,
+      createdAt: data.createdAt,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: getNetworkMessage(error),
+    };
+  }
+}

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { ActivityIndicator, Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { AvatarButton } from '../components/sentri-ui';
 import { theme } from '../design/tokens';
 import { calendarTags } from '../features/home/timetable-fixtures';
@@ -18,6 +19,7 @@ import {
 } from '../features/home/timetable-intelligence';
 import type { CalendarTag, ClassEntry, UploadMeta, UploadSource, ViewMode } from '../features/home/timetable-types';
 import { PERSISTENT_KEYS } from '../lib/persistent-keys';
+import { uploadTimetableScreenshot } from '../lib/timetable-api';
 import { usePersistedState } from '../lib/use-persisted-state';
 
 type HomeScreenProps = {
@@ -30,9 +32,10 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
   const [viewMode, setViewMode] = useState<ViewMode>('today');
   const [focusedDate, setFocusedDate] = useState(() => new Date());
   const [hoveredClassId, setHoveredClassId] = useState<string | null>(null);
-  const [uploadState, setUploadState] = useState<'idle' | 'uploading' | 'updated'>('idle');
+  const [uploadState, setUploadState] = useState<'idle' | 'uploading' | 'updated' | 'error'>('idle');
   const [uploadSheetOpen, setUploadSheetOpen] = useState(false);
   const [uploadSource, setUploadSource] = useState<UploadSource>('share');
+  const [uploadMessage, setUploadMessage] = useState<string | null>(null);
   const { value: lastUploadMeta, setValue: setLastUploadMeta } = usePersistedState<UploadMeta | null>(
     PERSISTENT_KEYS.homeUploadMeta,
     null
@@ -51,13 +54,65 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
     : `${formatWeekdayShort(focusedDate)}, ${focusedDate.getDate()} ${formatMonthShort(focusedDate)}`;
 
   useEffect(() => {
-    if (uploadState !== 'updated') {
+    if (uploadState !== 'updated' && uploadState !== 'error') {
       return;
     }
 
     const timeout = setTimeout(() => setUploadState('idle'), 2200);
     return () => clearTimeout(timeout);
   }, [uploadState]);
+
+  async function handleUploadConfirm() {
+    setUploadState('uploading');
+    setUploadMessage(null);
+
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      setUploadState('error');
+      setUploadMessage('Allow Photos access to upload the new timetable screenshot.');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: false,
+      quality: 1,
+    });
+
+    if (result.canceled || !result.assets[0]) {
+      setUploadState('idle');
+      return;
+    }
+
+    const asset = result.assets[0];
+    const name = asset.fileName ?? `timetable-${Date.now()}.jpg`;
+    const mimeType = asset.mimeType ?? 'image/jpeg';
+    const sourceLabel = uploadSource === 'mail' ? 'outlook-screenshot' : uploadSource;
+    const uploadResult = await uploadTimetableScreenshot({
+      uri: asset.uri,
+      name,
+      mimeType,
+      sourceHint: sourceLabel,
+      sourceNotes: `Uploaded from ${uploadSource} on Home`,
+    });
+
+    if (!uploadResult.ok) {
+      setUploadState('error');
+      setUploadMessage(uploadResult.message);
+      return;
+    }
+
+    setLastUploadMeta({
+      batchId: uploadResult.batchId,
+      source: uploadSource,
+      timestamp: uploadResult.createdAt ?? new Date().toISOString(),
+      imageName: uploadResult.sourceImageName,
+      status: uploadResult.status,
+    });
+    setUploadSheetOpen(false);
+    setUploadState('updated');
+    setUploadMessage(uploadResult.sourceImageName ? `${uploadResult.sourceImageName} uploaded.` : 'Upload complete.');
+  }
 
   return (
     <ScrollView
@@ -72,11 +127,21 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
           <Text style={styles.topDate}>{formatLongDate(focusedDate)}</Text>
         </View>
         <Pressable
-          style={[styles.topUploadButton, uploadState === 'updated' && styles.topUploadButtonDone]}
+          style={[
+            styles.topUploadButton,
+            uploadState === 'updated' && styles.topUploadButtonDone,
+            uploadState === 'error' && styles.topUploadButtonError,
+          ]}
           onPress={() => setUploadSheetOpen(true)}
         >
           <Text style={styles.topUploadButtonText}>
-            {uploadState === 'uploading' ? 'Uploading' : uploadState === 'updated' ? 'Updated' : 'Upload'}
+            {uploadState === 'uploading'
+              ? 'Uploading'
+              : uploadState === 'updated'
+                ? 'Updated'
+                : uploadState === 'error'
+                  ? 'Retry'
+                  : 'Upload'}
           </Text>
         </Pressable>
       </View>
@@ -139,14 +204,32 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
           <Text style={styles.refreshBannerBody}>{refreshInsight.body}</Text>
         </View>
         <Pressable
-          style={[styles.refreshBannerButton, uploadState === 'updated' && styles.refreshBannerButtonDone]}
+          style={[
+            styles.refreshBannerButton,
+            uploadState === 'updated' && styles.refreshBannerButtonDone,
+            uploadState === 'error' && styles.refreshBannerButtonError,
+          ]}
           onPress={() => setUploadSheetOpen(true)}
         >
           <Text style={styles.refreshBannerButtonText}>
-            {uploadState === 'uploading' ? 'Uploading' : uploadState === 'updated' ? 'Refreshed' : 'Upload'}
+            {uploadState === 'uploading'
+              ? 'Uploading'
+              : uploadState === 'updated'
+                ? 'Refreshed'
+                : uploadState === 'error'
+                  ? 'Retry upload'
+                  : 'Upload'}
           </Text>
         </Pressable>
       </View>
+
+      {uploadMessage ? (
+        <View style={[styles.uploadNotice, uploadState === 'error' && styles.uploadNoticeError]}>
+          <Text style={[styles.uploadNoticeText, uploadState === 'error' && styles.uploadNoticeTextError]}>
+            {uploadMessage}
+          </Text>
+        </View>
+      ) : null}
 
       <View style={styles.segmentedControl}>
         {(['today', 'week', 'month'] as ViewMode[]).map((mode) => (
@@ -380,13 +463,8 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
         uploadSource={uploadSource}
         onSelectSource={setUploadSource}
         onClose={() => setUploadSheetOpen(false)}
-        onConfirm={() => {
-          setUploadState('uploading');
-          const nextMeta = { source: uploadSource, timestamp: new Date().toISOString() };
-          setLastUploadMeta(nextMeta);
-          setUploadSheetOpen(false);
-          setTimeout(() => setUploadState('updated'), 260);
-        }}
+        uploadState={uploadState}
+        onConfirm={handleUploadConfirm}
       />
     </ScrollView>
   );
@@ -397,14 +475,18 @@ function UploadSheet({
   uploadSource,
   onSelectSource,
   onClose,
+  uploadState,
   onConfirm,
 }: {
   visible: boolean;
   uploadSource: 'share' | 'mail' | 'photos';
   onSelectSource: (source: 'share' | 'mail' | 'photos') => void;
   onClose: () => void;
-  onConfirm: () => void;
+  uploadState: 'idle' | 'uploading' | 'updated' | 'error';
+  onConfirm: () => void | Promise<void>;
 }) {
+  const uploading = uploadState === 'uploading';
+
   return (
     <Modal transparent visible={visible} animationType="fade" onRequestClose={onClose}>
       <View style={styles.modalBackdrop}>
@@ -413,7 +495,8 @@ function UploadSheet({
           <Text style={styles.modalKicker}>Weekly refresh</Text>
           <Text style={styles.modalTitle}>How are you adding the new timetable?</Text>
           <Text style={styles.modalBody}>
-            Pick the source you usually use. The screenshot parser can plug into this step next.
+            Pick the source you usually use, then choose the screenshot from Photos. The backend will create
+            a timetable upload batch from that image.
           </Text>
 
           <View style={styles.modalOptions}>
@@ -427,6 +510,7 @@ function UploadSheet({
                 <Pressable
                   key={value}
                   style={[styles.modalOption, active && styles.modalOptionActive]}
+                  disabled={uploading}
                   onPress={() => onSelectSource(value as 'share' | 'mail' | 'photos')}
                 >
                   <Text style={[styles.modalOptionText, active && styles.modalOptionTextActive]}>{label}</Text>
@@ -436,11 +520,11 @@ function UploadSheet({
           </View>
 
           <View style={styles.modalActions}>
-            <Pressable style={styles.modalActionGhost} onPress={onClose}>
+            <Pressable style={styles.modalActionGhost} onPress={onClose} disabled={uploading}>
               <Text style={styles.modalActionGhostText}>Cancel</Text>
             </Pressable>
-            <Pressable style={styles.modalActionFilled} onPress={onConfirm}>
-              <Text style={styles.modalActionFilledText}>Stage upload</Text>
+            <Pressable style={styles.modalActionFilled} onPress={() => void onConfirm()} disabled={uploading}>
+              {uploading ? <ActivityIndicator color="#FFFFFF" /> : <Text style={styles.modalActionFilledText}>Choose screenshot</Text>}
             </Pressable>
           </View>
         </View>
@@ -495,10 +579,31 @@ const styles = StyleSheet.create({
   topUploadButtonDone: {
     backgroundColor: theme.colors.accent,
   },
+  topUploadButtonError: {
+    backgroundColor: '#FCE8E6',
+  },
   topUploadButtonText: {
     color: theme.colors.accentStrong,
     fontSize: 13,
     fontWeight: '800',
+  },
+  uploadNotice: {
+    marginTop: 14,
+    borderRadius: 16,
+    backgroundColor: theme.colors.surfaceAlt,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  uploadNoticeError: {
+    backgroundColor: '#FCE8E6',
+  },
+  uploadNoticeText: {
+    color: theme.colors.textSoft,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  uploadNoticeTextError: {
+    color: '#C5221F',
   },
   modalBackdrop: {
     flex: 1,
@@ -730,6 +835,9 @@ const styles = StyleSheet.create({
   },
   refreshBannerButtonDone: {
     backgroundColor: theme.colors.accent,
+  },
+  refreshBannerButtonError: {
+    backgroundColor: '#FCE8E6',
   },
   refreshBannerButtonText: {
     color: theme.colors.accentStrong,

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -58,9 +58,22 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
       return;
     }
 
-    const timeout = setTimeout(() => setUploadState('idle'), 2200);
+    const timeout = setTimeout(() => {
+      setUploadState('idle');
+      if (uploadState === 'error') {
+        setUploadMessage(null);
+      }
+    }, 2200);
     return () => clearTimeout(timeout);
   }, [uploadState]);
+
+  function openUploadSheet() {
+    if (uploadState === 'error') {
+      setUploadState('idle');
+      setUploadMessage(null);
+    }
+    setUploadSheetOpen(true);
+  }
 
   async function handleUploadConfirm() {
     setUploadState('uploading');
@@ -132,7 +145,8 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
             uploadState === 'updated' && styles.topUploadButtonDone,
             uploadState === 'error' && styles.topUploadButtonError,
           ]}
-          onPress={() => setUploadSheetOpen(true)}
+          onPress={openUploadSheet}
+          disabled={uploadState === 'uploading'}
         >
           <Text style={styles.topUploadButtonText}>
             {uploadState === 'uploading'
@@ -209,7 +223,8 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
             uploadState === 'updated' && styles.refreshBannerButtonDone,
             uploadState === 'error' && styles.refreshBannerButtonError,
           ]}
-          onPress={() => setUploadSheetOpen(true)}
+          onPress={openUploadSheet}
+          disabled={uploadState === 'uploading'}
         >
           <Text style={styles.refreshBannerButtonText}>
             {uploadState === 'uploading'
@@ -498,6 +513,14 @@ function UploadSheet({
             Pick the source you usually use, then choose the screenshot from Photos. The backend will create
             a timetable upload batch from that image.
           </Text>
+          <Text style={styles.modalHint}>
+            Selected source:{' '}
+            {uploadSource === 'mail'
+              ? 'Outlook screenshot'
+              : uploadSource === 'photos'
+                ? 'Photos'
+                : 'Share into Sentri'}
+          </Text>
 
           <View style={styles.modalOptions}>
             {[
@@ -639,6 +662,12 @@ const styles = StyleSheet.create({
     color: theme.colors.textSoft,
     fontSize: 14,
     lineHeight: 20,
+  },
+  modalHint: {
+    marginTop: 12,
+    color: theme.colors.text,
+    fontSize: 13,
+    fontWeight: '600',
   },
   modalOptions: {
     marginTop: 16,

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,6 +48,16 @@ Returns service status.
 
 Creates a placeholder timetable batch from screenshot metadata.
 
+`POST /timetable-batches/uploads`
+
+Accepts `multipart/form-data` with:
+
+- `file`: timetable screenshot image
+- `sourceHint`: optional source tag such as `share`, `photos`, or `outlook-screenshot`
+- `sourceNotes`: optional note about where the upload came from
+
+The backend stores the screenshot locally and creates a placeholder batch ready for OCR parsing.
+
 `GET /timetable-batches`
 
 Lists all timetable batches.

--- a/backend/src/main/java/com/sentri/backend/SentriBackendApplication.java
+++ b/backend/src/main/java/com/sentri/backend/SentriBackendApplication.java
@@ -1,11 +1,14 @@
 package com.sentri.backend;
 
+import com.sentri.backend.config.TimetableUploadProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
 @EnableCaching
+@EnableConfigurationProperties(TimetableUploadProperties.class)
 public class SentriBackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/sentri/backend/config/TimetableUploadProperties.java
+++ b/backend/src/main/java/com/sentri/backend/config/TimetableUploadProperties.java
@@ -1,0 +1,11 @@
+package com.sentri.backend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sentri.timetable.upload")
+public record TimetableUploadProperties(String storageDir) {
+
+    public String resolvedStorageDir() {
+        return storageDir == null || storageDir.isBlank() ? "./data/timetable-uploads" : storageDir;
+    }
+}

--- a/backend/src/main/java/com/sentri/backend/controller/TimetableBatchController.java
+++ b/backend/src/main/java/com/sentri/backend/controller/TimetableBatchController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -40,6 +42,16 @@ public class TimetableBatchController {
     @PostMapping
     public ResponseEntity<TimetableBatchDetailResponse> create(@RequestBody(required = false) CreateTimetableBatchRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(timetableBatchService.createPlaceholderBatch(request));
+    }
+
+    @PostMapping(value = "/uploads", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<TimetableBatchDetailResponse> createUpload(
+            @RequestPart("file") MultipartFile file,
+            @RequestPart(name = "sourceHint", required = false) String sourceHint,
+            @RequestPart(name = "sourceNotes", required = false) String sourceNotes
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(timetableBatchService.createUploadBatch(file, sourceHint, sourceNotes));
     }
 
     @GetMapping

--- a/backend/src/main/java/com/sentri/backend/domain/TimetableBatch.java
+++ b/backend/src/main/java/com/sentri/backend/domain/TimetableBatch.java
@@ -52,6 +52,7 @@ public class TimetableBatch {
     private String sourceImageName;
     private String sourceImageMimeType;
     private String sourceImageChecksum;
+    private String sourceImageStoragePath;
     private String sourceHint;
 
     @Enumerated(EnumType.STRING)
@@ -165,6 +166,14 @@ public class TimetableBatch {
 
     public void setSourceImageChecksum(String sourceImageChecksum) {
         this.sourceImageChecksum = sourceImageChecksum;
+    }
+
+    public String getSourceImageStoragePath() {
+        return sourceImageStoragePath;
+    }
+
+    public void setSourceImageStoragePath(String sourceImageStoragePath) {
+        this.sourceImageStoragePath = sourceImageStoragePath;
     }
 
     public String getSourceHint() {

--- a/backend/src/main/java/com/sentri/backend/service/StoredTimetableUpload.java
+++ b/backend/src/main/java/com/sentri/backend/service/StoredTimetableUpload.java
@@ -1,0 +1,9 @@
+package com.sentri.backend.service;
+
+public record StoredTimetableUpload(
+        String originalFilename,
+        String mimeType,
+        String checksum,
+        String storagePath
+) {
+}

--- a/backend/src/main/java/com/sentri/backend/service/TimetableBatchService.java
+++ b/backend/src/main/java/com/sentri/backend/service/TimetableBatchService.java
@@ -4,12 +4,15 @@ import com.sentri.backend.dto.request.CreateTimetableBatchRequest;
 import com.sentri.backend.dto.request.ParsedTimetableImportRequest;
 import com.sentri.backend.dto.response.TimetableBatchDetailResponse;
 import com.sentri.backend.dto.response.TimetableBatchSummaryResponse;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface TimetableBatchService {
 
     TimetableBatchDetailResponse createPlaceholderBatch(CreateTimetableBatchRequest request);
+
+    TimetableBatchDetailResponse createUploadBatch(MultipartFile file, String sourceHint, String sourceNotes);
 
     List<TimetableBatchSummaryResponse> listBatches();
 

--- a/backend/src/main/java/com/sentri/backend/service/TimetableBatchServiceImpl.java
+++ b/backend/src/main/java/com/sentri/backend/service/TimetableBatchServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Comparator;
 import java.util.List;
@@ -25,9 +26,14 @@ import java.util.List;
 public class TimetableBatchServiceImpl implements TimetableBatchService {
 
     private final TimetableBatchRepository timetableBatchRepository;
+    private final TimetableUploadStorageService timetableUploadStorageService;
 
-    public TimetableBatchServiceImpl(TimetableBatchRepository timetableBatchRepository) {
+    public TimetableBatchServiceImpl(
+            TimetableBatchRepository timetableBatchRepository,
+            TimetableUploadStorageService timetableUploadStorageService
+    ) {
         this.timetableBatchRepository = timetableBatchRepository;
+        this.timetableUploadStorageService = timetableUploadStorageService;
     }
 
     @Override
@@ -37,6 +43,23 @@ public class TimetableBatchServiceImpl implements TimetableBatchService {
         TimetableBatch batch = new TimetableBatch();
         batch.setStatus(TimetableBatchStatus.PLACEHOLDER);
         applyMetadata(batch, request == null ? null : request.metadata());
+        TimetableBatch saved = timetableBatchRepository.saveAndFlush(batch);
+        return toDetailResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    @CacheEvict(cacheNames = {"timetableBatchSummaries", "timetableBatchDetails"}, allEntries = true)
+    public TimetableBatchDetailResponse createUploadBatch(MultipartFile file, String sourceHint, String sourceNotes) {
+        StoredTimetableUpload storedUpload = timetableUploadStorageService.store(file);
+        TimetableBatch batch = new TimetableBatch();
+        batch.setStatus(TimetableBatchStatus.PLACEHOLDER);
+        batch.setSourceImageName(storedUpload.originalFilename());
+        batch.setSourceImageMimeType(storedUpload.mimeType());
+        batch.setSourceImageChecksum(storedUpload.checksum());
+        batch.setSourceImageStoragePath(storedUpload.storagePath());
+        batch.setSourceHint(sourceHint);
+        batch.setSourceNotes(sourceNotes);
         TimetableBatch saved = timetableBatchRepository.saveAndFlush(batch);
         return toDetailResponse(saved);
     }

--- a/backend/src/main/java/com/sentri/backend/service/TimetableUploadStorageService.java
+++ b/backend/src/main/java/com/sentri/backend/service/TimetableUploadStorageService.java
@@ -1,0 +1,8 @@
+package com.sentri.backend.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface TimetableUploadStorageService {
+
+    StoredTimetableUpload store(MultipartFile file);
+}

--- a/backend/src/main/java/com/sentri/backend/service/TimetableUploadStorageServiceImpl.java
+++ b/backend/src/main/java/com/sentri/backend/service/TimetableUploadStorageServiceImpl.java
@@ -1,0 +1,76 @@
+package com.sentri.backend.service;
+
+import com.sentri.backend.config.TimetableUploadProperties;
+import com.sentri.backend.exception.BadRequestException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.UUID;
+
+@Service
+public class TimetableUploadStorageServiceImpl implements TimetableUploadStorageService {
+
+    private final Path storageRoot;
+
+    public TimetableUploadStorageServiceImpl(TimetableUploadProperties properties) {
+        this.storageRoot = Path.of(properties.resolvedStorageDir()).toAbsolutePath().normalize();
+    }
+
+    @Override
+    public StoredTimetableUpload store(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BadRequestException("A timetable screenshot is required");
+        }
+
+        String originalFilename = sanitizeFilename(file.getOriginalFilename());
+        String extension = extractExtension(originalFilename);
+        String storageFilename = UUID.randomUUID() + extension;
+        Path destination = storageRoot.resolve(storageFilename);
+
+        try {
+            Files.createDirectories(storageRoot);
+            try (InputStream inputStream = file.getInputStream()) {
+                Files.copy(inputStream, destination, StandardCopyOption.REPLACE_EXISTING);
+            }
+            return new StoredTimetableUpload(
+                    originalFilename,
+                    file.getContentType(),
+                    sha256(destination),
+                    destination.toString()
+            );
+        } catch (IOException exception) {
+            throw new IllegalStateException("Could not store timetable screenshot", exception);
+        }
+    }
+
+    private String sanitizeFilename(String originalFilename) {
+        String candidate = StringUtils.hasText(originalFilename) ? originalFilename : "timetable-upload";
+        return Path.of(candidate).getFileName().toString().replaceAll("[^A-Za-z0-9._-]", "-");
+    }
+
+    private String extractExtension(String filename) {
+        int lastDot = filename.lastIndexOf('.');
+        if (lastDot < 0 || lastDot == filename.length() - 1) {
+            return "";
+        }
+        return filename.substring(lastDot);
+    }
+
+    private String sha256(Path file) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(Files.readAllBytes(file)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is not available", exception);
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -20,3 +20,8 @@ spring:
 
 server:
   port: ${SERVER_PORT:8080}
+
+sentri:
+  timetable:
+    upload:
+      storage-dir: ${SENTRI_TIMETABLE_UPLOAD_DIR:./data/timetable-uploads}

--- a/backend/src/test/java/com/sentri/backend/service/TimetableBatchServiceTest.java
+++ b/backend/src/test/java/com/sentri/backend/service/TimetableBatchServiceTest.java
@@ -11,8 +11,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -104,5 +107,31 @@ class TimetableBatchServiceTest {
         assertThat(saved.entries().get(0).subjectName()).isEqualTo("DM & SM");
         TimetableBatch persisted = timetableBatchRepository.findByIdWithEntries(created.id()).orElseThrow();
         assertThat(persisted.getEntries()).hasSize(1);
+    }
+
+    @Test
+    void createsUploadBatchAndPersistsStoredScreenshotMetadata() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "week-13.png",
+                "image/png",
+                "fake-image".getBytes()
+        );
+
+        TimetableBatchDetailResponse created = timetableBatchService.createUploadBatch(
+                file,
+                "outlook-screenshot",
+                "Uploaded from Home"
+        );
+
+        assertThat(created.id()).isNotNull();
+        assertThat(created.status()).isEqualTo("PLACEHOLDER");
+        assertThat(created.sourceImageName()).isEqualTo("week-13.png");
+        assertThat(created.sourceImageMimeType()).isEqualTo("image/png");
+        assertThat(created.sourceImageChecksum()).isNotBlank();
+
+        TimetableBatch persisted = timetableBatchRepository.findByIdWithEntries(created.id()).orElseThrow();
+        assertThat(persisted.getSourceImageStoragePath()).isNotBlank();
+        assertThat(Files.exists(Path.of(persisted.getSourceImageStoragePath()))).isTrue();
     }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -10,3 +10,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+
+sentri:
+  timetable:
+    upload:
+      storage-dir: ${java.io.tmpdir}/sentri-test-uploads


### PR DESCRIPTION
## Summary
- add a real Spring Boot multipart intake endpoint for timetable screenshots
- wire Home upload to the native image picker and backend request path
- add tests and docs for the new upload flow

## Testing
- cd app && npx tsc --noEmit
- cd backend && mvn -Dmaven.repo.local=.m2 test

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now launch the native image picker to select timetable screenshots directly from their device.
  * Timetable uploads are now processed end-to-end by the backend: screenshots are uploaded, stored, and queued for parsing.
  * Added error handling with retry capability for failed uploads.
  * Enhanced upload status messaging, including confirmation of successful uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->