### PR TITLE
Show parser status visibility on the Home upload banner

### DIFF
--- a/app/src/features/home/timetable-intelligence.ts
+++ b/app/src/features/home/timetable-intelligence.ts
@@ -141,10 +141,11 @@ export function getRefreshInsight(
 
   const refreshDue = today >= getRefreshSaturday(today);
   if (lastUploadMeta) {
+    const parserStatus = formatParserStatus(lastUploadMeta);
     return {
       state: refreshDue ? 'due' : 'fresh',
-      title: refreshDue ? 'Week ready for a fresh upload' : 'Week ready',
-      body: `Last staged from ${formatUploadSource(lastUploadMeta.source)} on ${formatShortDateTime(
+      title: parserStatus.title,
+      body: `${parserStatus.body} Last staged from ${formatUploadSource(lastUploadMeta.source)} on ${formatShortDateTime(
         lastUploadMeta.timestamp
       )}${lastUploadMeta.imageName ? ` • ${lastUploadMeta.imageName}` : ''}.`,
       urgency: refreshDue ? 'high' : 'low',
@@ -183,6 +184,44 @@ export function formatUploadSource(source: UploadSource) {
   if (source === 'mail') return 'Outlook screenshot';
   if (source === 'photos') return 'Photos';
   return 'Share into Sentri';
+}
+
+export function formatParserBadge(status?: string) {
+  if (status === 'PARSED') return 'Parsed';
+  if (status === 'VERIFIED') return 'Verified';
+  if (status === 'PLACEHOLDER') return 'Awaiting parser';
+  return 'No parser status';
+}
+
+function formatParserStatus(lastUploadMeta: UploadMeta) {
+  if (lastUploadMeta.status === 'VERIFIED') {
+    return {
+      title: 'Timetable verified',
+      body:
+        lastUploadMeta.entryCount && lastUploadMeta.entryCount > 0
+          ? `${lastUploadMeta.entryCount} timetable items verified for this upload.`
+          : 'The latest timetable upload has been verified and is ready to use.',
+    };
+  }
+
+  if (lastUploadMeta.status === 'PARSED') {
+    const confidence =
+      typeof lastUploadMeta.extractionConfidence === 'number'
+        ? ` Parser confidence ${Math.round(lastUploadMeta.extractionConfidence * 100)}%.`
+        : '';
+    return {
+      title: 'Parser finished',
+      body:
+        lastUploadMeta.entryCount && lastUploadMeta.entryCount > 0
+          ? `${lastUploadMeta.entryCount} timetable items were parsed.${confidence}`
+          : `The latest timetable upload has been parsed.${confidence}`,
+    };
+  }
+
+  return {
+    title: 'Parser pending',
+    body: 'The latest screenshot is uploaded and waiting for OCR and timetable extraction.',
+  };
 }
 
 export function formatShortDateTime(value: string) {

--- a/app/src/features/home/timetable-types.ts
+++ b/app/src/features/home/timetable-types.ts
@@ -25,4 +25,7 @@ export type UploadMeta = {
   timestamp: string;
   imageName?: string;
   status?: string;
+  updatedAt?: string;
+  extractionConfidence?: number;
+  entryCount?: number;
 };

--- a/app/src/lib/timetable-api.ts
+++ b/app/src/lib/timetable-api.ts
@@ -13,6 +13,22 @@ export type TimetableUploadResult =
       message: string;
     };
 
+export type TimetableBatchStatusResult =
+  | {
+      ok: true;
+      batchId: number;
+      sourceImageName?: string;
+      status: string;
+      createdAt?: string;
+      updatedAt?: string;
+      extractionConfidence?: number;
+      entryCount: number;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
 export async function uploadTimetableScreenshot(payload: {
   uri: string;
   name: string;
@@ -53,6 +69,37 @@ export async function uploadTimetableScreenshot(payload: {
       sourceImageName: data.sourceImageName,
       status: data.status,
       createdAt: data.createdAt,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: getNetworkMessage(error),
+    };
+  }
+}
+
+export async function getTimetableBatchStatus(batchId: number): Promise<TimetableBatchStatusResult> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/timetable-batches/${batchId}`);
+    const rawText = await response.text();
+    const data = rawText ? JSON.parse(rawText) : {};
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        message: extractErrorMessage(data, 'Could not load the latest parser status.'),
+      };
+    }
+
+    return {
+      ok: true,
+      batchId: data.id,
+      sourceImageName: data.sourceImageName,
+      status: data.status,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+      extractionConfidence: data.extractionConfidence ?? undefined,
+      entryCount: Array.isArray(data.entries) ? data.entries.length : 0,
     };
   } catch (error) {
     return {

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -8,6 +8,7 @@ import {
   buildMonthRows,
   buildWeekDates,
   dayKeyForDate,
+  formatParserBadge,
   formatLongDate,
   formatMonthShort,
   formatMonthYear,
@@ -19,7 +20,7 @@ import {
 } from '../features/home/timetable-intelligence';
 import type { CalendarTag, ClassEntry, UploadMeta, UploadSource, ViewMode } from '../features/home/timetable-types';
 import { PERSISTENT_KEYS } from '../lib/persistent-keys';
-import { uploadTimetableScreenshot } from '../lib/timetable-api';
+import { getTimetableBatchStatus, uploadTimetableScreenshot } from '../lib/timetable-api';
 import { usePersistedState } from '../lib/use-persisted-state';
 
 type HomeScreenProps = {
@@ -66,6 +67,47 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
     }, 2200);
     return () => clearTimeout(timeout);
   }, [uploadState]);
+
+  useEffect(() => {
+    if (!lastUploadMeta?.batchId) {
+      return;
+    }
+
+    let active = true;
+
+    void (async () => {
+      const statusResult = await getTimetableBatchStatus(lastUploadMeta.batchId);
+      if (!active || !statusResult.ok) {
+        return;
+      }
+
+      const nextMeta: UploadMeta = {
+        ...lastUploadMeta,
+        timestamp: statusResult.updatedAt ?? statusResult.createdAt ?? lastUploadMeta.timestamp,
+        imageName: statusResult.sourceImageName ?? lastUploadMeta.imageName,
+        status: statusResult.status,
+        updatedAt: statusResult.updatedAt,
+        extractionConfidence: statusResult.extractionConfidence,
+        entryCount: statusResult.entryCount,
+      };
+
+      const changed =
+        nextMeta.timestamp !== lastUploadMeta.timestamp ||
+        nextMeta.imageName !== lastUploadMeta.imageName ||
+        nextMeta.status !== lastUploadMeta.status ||
+        nextMeta.updatedAt !== lastUploadMeta.updatedAt ||
+        nextMeta.extractionConfidence !== lastUploadMeta.extractionConfidence ||
+        nextMeta.entryCount !== lastUploadMeta.entryCount;
+
+      if (changed) {
+        setLastUploadMeta(nextMeta);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [lastUploadMeta, setLastUploadMeta]);
 
   function openUploadSheet() {
     if (uploadState === 'error') {
@@ -121,6 +163,8 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
       timestamp: uploadResult.createdAt ?? new Date().toISOString(),
       imageName: uploadResult.sourceImageName,
       status: uploadResult.status,
+      updatedAt: uploadResult.createdAt,
+      entryCount: 0,
     });
     setUploadSheetOpen(false);
     setUploadState('updated');
@@ -214,7 +258,14 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
 
       <View style={styles.refreshBanner}>
         <View style={styles.refreshBannerCopy}>
-          <Text style={styles.refreshBannerTitle}>{refreshInsight.title}</Text>
+          <View style={styles.refreshBannerTitleRow}>
+            <Text style={styles.refreshBannerTitle}>{refreshInsight.title}</Text>
+            {lastUploadMeta?.status ? (
+              <View style={styles.parserBadge}>
+                <Text style={styles.parserBadgeText}>{formatParserBadge(lastUploadMeta.status)}</Text>
+              </View>
+            ) : null}
+          </View>
           <Text style={styles.refreshBannerBody}>{refreshInsight.body}</Text>
         </View>
         <Pressable
@@ -846,6 +897,12 @@ const styles = StyleSheet.create({
     gap: 4,
     flex: 1,
   },
+  refreshBannerTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
   refreshBannerTitle: {
     color: theme.colors.text,
     fontSize: 15,
@@ -855,6 +912,21 @@ const styles = StyleSheet.create({
     color: theme.colors.textSoft,
     fontSize: 13,
     lineHeight: 18,
+  },
+  parserBadge: {
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.surfaceAlt,
+    borderWidth: 1,
+    borderColor: theme.colors.line,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  parserBadgeText: {
+    color: theme.colors.accentStrong,
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
   },
   refreshBannerButton: {
     borderRadius: theme.radius.pill,


### PR DESCRIPTION
## Summary
- sync the last uploaded timetable batch from the backend when Home loads
- expose parser state labels for PLACEHOLDER, PARSED, and VERIFIED batches
- show parser status directly inside the Home refresh banner

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Enhanced timetable upload status tracking with real-time parser state updates displayed in the refresh banner
* Added visual parser status badges showing verification progress (Verified, Parsed, Pending)
* Status insights now include extraction confidence percentage and parsed entry count details
* Improved status messaging that dynamically reflects parsing progress and readiness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->