### PR TITLE
Harden auth session restore across app restarts

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -6,10 +6,13 @@ import { CapsuleTabBar, DrawerSheet } from './src/components/sentri-ui';
 import { theme, type TabKey } from './src/design/tokens';
 import {
   clearStoredSessionToken,
+  clearStoredSessionUser,
   getStoredActiveTab,
   getStoredSessionToken,
+  getStoredSessionUser,
   storeActiveTab,
   storeSessionToken,
+  storeSessionUser,
 } from './src/lib/auth-storage';
 import * as authApi from './src/lib/api';
 import { useMountedTabs } from './src/lib/use-mounted-tabs';
@@ -98,14 +101,25 @@ export default function App() {
       return;
     }
 
+    const storedUser = await getStoredSessionUser();
+    if (storedUser) {
+      setSessionToken(storedToken);
+      setAuthenticatedUser(storedUser);
+      setAuthStatusMessage('Restoring your last session.');
+      setAuthInitializing(false);
+    }
+
     const result = await authApi.restoreSession(storedToken);
     if (result.ok && result.user) {
       setSessionToken(storedToken);
       setAuthenticatedUser(result.user);
+      await storeSessionUser(result.user);
       setAuthStatusMessage(result.message);
     } else {
       await clearStoredSessionToken();
+      await clearStoredSessionUser();
       setSessionToken(null);
+      setAuthenticatedUser(null);
       setAuthMode('login');
       setAuthStatusMessage(result.message);
     }
@@ -147,6 +161,7 @@ export default function App() {
 
     if (result.sessionToken && result.user) {
       await storeSessionToken(result.sessionToken);
+      await storeSessionUser(result.user);
       setSessionToken(result.sessionToken);
       setAuthenticatedUser(result.user);
       setPendingSignup(null);
@@ -168,6 +183,7 @@ export default function App() {
 
     if (result.ok && result.sessionToken && result.user) {
       await storeSessionToken(result.sessionToken);
+      await storeSessionUser(result.user);
       setSessionToken(result.sessionToken);
       setAuthenticatedUser(result.user);
       setPendingSignup(null);
@@ -183,6 +199,7 @@ export default function App() {
 
     if (result.ok && result.sessionToken && result.user) {
       await storeSessionToken(result.sessionToken);
+      await storeSessionUser(result.user);
       setSessionToken(result.sessionToken);
       setAuthenticatedUser(result.user);
       setPendingSignup(null);
@@ -197,6 +214,7 @@ export default function App() {
     }
 
     await clearStoredSessionToken();
+    await clearStoredSessionUser();
     setSessionToken(null);
     setAuthenticatedUser(null);
     setPendingSignup(null);

--- a/app/src/lib/auth-storage.ts
+++ b/app/src/lib/auth-storage.ts
@@ -1,7 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { UserProfile } from '../types/auth';
 import { PERSISTENT_KEYS } from './persistent-keys';
 
 const SESSION_TOKEN_KEY = PERSISTENT_KEYS.sessionToken;
+const SESSION_USER_KEY = PERSISTENT_KEYS.sessionUser;
 const ACTIVE_TAB_KEY = PERSISTENT_KEYS.activeTab;
 
 export async function getStoredSessionToken() {
@@ -14,6 +16,28 @@ export async function storeSessionToken(token: string) {
 
 export async function clearStoredSessionToken() {
   await AsyncStorage.removeItem(SESSION_TOKEN_KEY);
+}
+
+export async function getStoredSessionUser(): Promise<UserProfile | null> {
+  const raw = await AsyncStorage.getItem(SESSION_USER_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as UserProfile;
+  } catch {
+    await AsyncStorage.removeItem(SESSION_USER_KEY);
+    return null;
+  }
+}
+
+export async function storeSessionUser(profile: UserProfile) {
+  await AsyncStorage.setItem(SESSION_USER_KEY, JSON.stringify(profile));
+}
+
+export async function clearStoredSessionUser() {
+  await AsyncStorage.removeItem(SESSION_USER_KEY);
 }
 
 export async function getStoredActiveTab() {

--- a/app/src/lib/persistent-keys.ts
+++ b/app/src/lib/persistent-keys.ts
@@ -1,5 +1,6 @@
 export const PERSISTENT_KEYS = {
   sessionToken: 'sentri.sessionToken',
+  sessionUser: 'sentri.sessionUser',
   activeTab: 'sentri.activeTab',
   homeUploadMeta: 'sentri.homeUploadMeta',
   myspaceItems: 'sentri.myspace.items',


### PR DESCRIPTION
## Summary
- cache the last authenticated user profile alongside the session token
- restore the cached user immediately on app restart while session validation runs
- clear the cached profile if session restore fails or the user logs out

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session restoration now automatically preserves and retrieves your user profile information
  * Your account details are seamlessly restored when you reopen the app after closing it
  * Invalid or corrupted session data is automatically detected and cleaned up to ensure app stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->