### PR TITLE
Add weekly timetable upload history to Home

### DIFF
--- a/app/src/features/home/timetable-intelligence.ts
+++ b/app/src/features/home/timetable-intelligence.ts
@@ -193,6 +193,16 @@ export function formatParserBadge(status?: string) {
   return 'No parser status';
 }
 
+export function formatUploadHistoryTitle(status: string, entryCount: number) {
+  if (status === 'VERIFIED') {
+    return entryCount > 0 ? `${entryCount} verified items` : 'Verified upload';
+  }
+  if (status === 'PARSED') {
+    return entryCount > 0 ? `${entryCount} parsed items` : 'Parsed upload';
+  }
+  return 'Awaiting parser';
+}
+
 function formatParserStatus(lastUploadMeta: UploadMeta) {
   if (lastUploadMeta.status === 'VERIFIED') {
     return {

--- a/app/src/features/home/timetable-types.ts
+++ b/app/src/features/home/timetable-types.ts
@@ -29,3 +29,12 @@ export type UploadMeta = {
   extractionConfidence?: number;
   entryCount?: number;
 };
+
+export type TimetableUploadHistoryItem = {
+  batchId: number;
+  imageName?: string;
+  status: string;
+  createdAt?: string;
+  updatedAt?: string;
+  entryCount: number;
+};

--- a/app/src/lib/timetable-api.ts
+++ b/app/src/lib/timetable-api.ts
@@ -1,3 +1,4 @@
+import type { TimetableUploadHistoryItem } from '../features/home/timetable-types';
 import { API_BASE_URL, extractErrorMessage, getNetworkMessage } from './http-client';
 
 export type TimetableUploadResult =
@@ -23,6 +24,16 @@ export type TimetableBatchStatusResult =
       updatedAt?: string;
       extractionConfidence?: number;
       entryCount: number;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+export type TimetableHistoryResult =
+  | {
+      ok: true;
+      uploads: TimetableUploadHistoryItem[];
     }
   | {
       ok: false;
@@ -101,6 +112,39 @@ export async function getTimetableBatchStatus(batchId: number): Promise<Timetabl
       extractionConfidence: data.extractionConfidence ?? undefined,
       entryCount: Array.isArray(data.entries) ? data.entries.length : 0,
     };
+  } catch (error) {
+    return {
+      ok: false,
+      message: getNetworkMessage(error),
+    };
+  }
+}
+
+export async function listTimetableUploadHistory(limit = 4): Promise<TimetableHistoryResult> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/timetable-batches`);
+    const rawText = await response.text();
+    const data = rawText ? JSON.parse(rawText) : [];
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        message: extractErrorMessage(data, 'Could not load recent timetable uploads.'),
+      };
+    }
+
+    const uploads = Array.isArray(data)
+      ? data.slice(0, limit).map((item) => ({
+          batchId: item.id,
+          imageName: item.sourceImageName ?? undefined,
+          status: item.status,
+          createdAt: item.createdAt ?? undefined,
+          updatedAt: item.updatedAt ?? undefined,
+          entryCount: item.entryCount ?? 0,
+        }))
+      : [];
+
+    return { ok: true, uploads };
   } catch (error) {
     return {
       ok: false,

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -9,6 +9,8 @@ import {
   buildWeekDates,
   dayKeyForDate,
   formatParserBadge,
+  formatShortDateTime,
+  formatUploadHistoryTitle,
   formatLongDate,
   formatMonthShort,
   formatMonthYear,
@@ -18,9 +20,9 @@ import {
   getScheduleInsight,
   isSameDate,
 } from '../features/home/timetable-intelligence';
-import type { CalendarTag, ClassEntry, UploadMeta, UploadSource, ViewMode } from '../features/home/timetable-types';
+import type { CalendarTag, ClassEntry, TimetableUploadHistoryItem, UploadMeta, UploadSource, ViewMode } from '../features/home/timetable-types';
 import { PERSISTENT_KEYS } from '../lib/persistent-keys';
-import { getTimetableBatchStatus, uploadTimetableScreenshot } from '../lib/timetable-api';
+import { getTimetableBatchStatus, listTimetableUploadHistory, uploadTimetableScreenshot } from '../lib/timetable-api';
 import { usePersistedState } from '../lib/use-persisted-state';
 
 type HomeScreenProps = {
@@ -37,6 +39,7 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
   const [uploadSheetOpen, setUploadSheetOpen] = useState(false);
   const [uploadSource, setUploadSource] = useState<UploadSource>('share');
   const [uploadMessage, setUploadMessage] = useState<string | null>(null);
+  const [recentUploads, setRecentUploads] = useState<TimetableUploadHistoryItem[]>([]);
   const { value: lastUploadMeta, setValue: setLastUploadMeta } = usePersistedState<UploadMeta | null>(
     PERSISTENT_KEYS.homeUploadMeta,
     null
@@ -67,6 +70,22 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
     }, 2200);
     return () => clearTimeout(timeout);
   }, [uploadState]);
+
+  useEffect(() => {
+    let active = true;
+
+    void (async () => {
+      const historyResult = await listTimetableUploadHistory();
+      if (!active || !historyResult.ok) {
+        return;
+      }
+      setRecentUploads(historyResult.uploads);
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!lastUploadMeta?.batchId) {
@@ -102,6 +121,19 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
       if (changed) {
         setLastUploadMeta(nextMeta);
       }
+
+      setRecentUploads((current) => {
+        const nextItem: TimetableUploadHistoryItem = {
+          batchId: statusResult.batchId,
+          imageName: statusResult.sourceImageName ?? lastUploadMeta.imageName,
+          status: statusResult.status,
+          createdAt: statusResult.createdAt,
+          updatedAt: statusResult.updatedAt,
+          entryCount: statusResult.entryCount,
+        };
+        const others = current.filter((entry) => entry.batchId !== nextItem.batchId);
+        return [nextItem, ...others].slice(0, 4);
+      });
     })();
 
     return () => {
@@ -166,6 +198,17 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
       updatedAt: uploadResult.createdAt,
       entryCount: 0,
     });
+    setRecentUploads((current) => [
+      {
+        batchId: uploadResult.batchId,
+        imageName: uploadResult.sourceImageName,
+        status: uploadResult.status,
+        createdAt: uploadResult.createdAt,
+        updatedAt: uploadResult.createdAt,
+        entryCount: 0,
+      },
+      ...current.filter((entry) => entry.batchId !== uploadResult.batchId),
+    ].slice(0, 4));
     setUploadSheetOpen(false);
     setUploadState('updated');
     setUploadMessage(uploadResult.sourceImageName ? `${uploadResult.sourceImageName} uploaded.` : 'Upload complete.');
@@ -294,6 +337,29 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
           <Text style={[styles.uploadNoticeText, uploadState === 'error' && styles.uploadNoticeTextError]}>
             {uploadMessage}
           </Text>
+        </View>
+      ) : null}
+
+      {recentUploads.length ? (
+        <View style={styles.uploadHistoryCard}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Recent uploads</Text>
+            <Text style={styles.sectionAction}>{recentUploads.length} tracked</Text>
+          </View>
+          {recentUploads.map((upload, index) => (
+            <View key={upload.batchId} style={[styles.historyRow, index !== 0 && styles.historyRowBorder]}>
+              <View style={styles.historyCopy}>
+                <Text style={styles.historyTitle}>{upload.imageName ?? `Upload batch ${upload.batchId}`}</Text>
+                <Text style={styles.historyMeta}>
+                  {formatUploadHistoryTitle(upload.status, upload.entryCount)} •{' '}
+                  {formatShortDateTime(upload.updatedAt ?? upload.createdAt ?? '')}
+                </Text>
+              </View>
+              <View style={styles.historyBadge}>
+                <Text style={styles.historyBadgeText}>{formatParserBadge(upload.status)}</Text>
+              </View>
+            </View>
+          ))}
         </View>
       ) : null}
 
@@ -927,6 +993,54 @@ const styles = StyleSheet.create({
     fontWeight: '800',
     letterSpacing: 0.5,
     textTransform: 'uppercase',
+  },
+  uploadHistoryCard: {
+    marginTop: 14,
+    borderRadius: 24,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.line,
+    padding: 16,
+  },
+  historyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingVertical: 12,
+  },
+  historyRowBorder: {
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.line,
+  },
+  historyCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  historyTitle: {
+    color: theme.colors.text,
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  historyMeta: {
+    color: theme.colors.textSoft,
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  historyBadge: {
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.surfaceAlt,
+    borderWidth: 1,
+    borderColor: theme.colors.line,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  historyBadgeText: {
+    color: theme.colors.accentStrong,
+    fontSize: 11,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
   },
   refreshBannerButton: {
     borderRadius: theme.radius.pill,


### PR DESCRIPTION
## Summary
- fetch recent timetable upload batches on Home
- surface the latest upload attempts in a short history block
- show parser state and timestamps so students can tell which screenshot is current

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Recent uploads" card to the home screen that displays your 4 most recent timetable uploads. Each upload entry includes the file name (or batch reference), current parser status with entry/record count, last update timestamp, and a visual status indicator badge for easy tracking of your upload progress and history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->