### PR TITLE
chore: add GitHub issue templates and issue-linked PR workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report a reproducible defect in Sentri
+title: "[bug] "
+labels: [bug]
+assignees: []
+---
+
+## Problem Summary
+
+Describe the bug in one paragraph.
+
+## Steps To Reproduce
+
+1. Go to ...
+2. Tap/click ...
+3. Observe ...
+
+## Expected Behavior
+
+Describe what should happen.
+
+## Actual Behavior
+
+Describe what happens now.
+
+## Environment
+
+- App version/commit:
+- Device/OS:
+- Backend version:
+
+## Logs / Screenshots
+
+Attach any logs, stack traces, or screenshots.
+
+## Additional Context
+
+Anything else that helps narrow down root cause.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Sentri architecture docs
+    url: https://github.com/SahilKumar75/sentri/tree/main/docs
+    about: Review architecture and AI logic docs before opening a broad design issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Propose a new capability or improvement
+title: "[feature] "
+labels: [enhancement]
+assignees: []
+---
+
+## Problem To Solve
+
+What user pain or workflow gap does this address?
+
+## Proposed Solution
+
+Describe the proposed behavior.
+
+## Alternatives Considered
+
+List alternatives and why they were not selected.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Scope Notes
+
+What is explicitly in scope and out of scope?
+
+## Additional Context
+
+Any diagrams, links, or references.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,14 +4,24 @@
 - why it changed
 - what areas are affected
 
+## Linked Issue
+
+- Closes #
+
 ## Checklist
 
 - [ ] I did not push directly to `main`
 - [ ] This branch has small logical commits
 - [ ] I reviewed my own diff before requesting merge
+- [ ] This PR links an issue
 - [ ] `app` compiles with `npx tsc --noEmit`
 - [ ] `backend` tests pass with `mvn test`
 - [ ] Any architecture-impacting changes are documented
+
+## Test Plan
+
+- how this was tested
+- what could not be tested locally
 
 ## Screens / API Notes
 
@@ -23,3 +33,7 @@
 
 - known gaps:
 - follow-up work:
+
+## Review Focus
+
+- areas where reviewer attention is most useful:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,14 @@ Sentri should be developed using a review-first workflow even when only one deve
 
 ### Required Git Flow
 
-1. Never push directly to `main`.
-2. Create a feature branch for every change.
-3. Keep commits small and logical.
-4. Push the branch to GitHub.
-5. Open a pull request.
-6. Review the full diff before merging.
-7. Merge only after the review notes are addressed.
+1. Open an issue for each non-trivial change.
+2. Never push directly to `main`.
+3. Create a feature branch for every change.
+4. Keep commits small and logical.
+5. Push the branch to GitHub.
+6. Open a pull request linked to the issue (for example: `Closes #123`).
+7. Review the full diff before merging.
+8. Merge only after the review notes are addressed.
 
 ### Branch Naming
 
@@ -42,6 +43,12 @@ Before merging a PR, check:
 - mobile build still compiles
 - no dead demo-only code path was introduced silently
 - performance-sensitive reads and renders are considered
+
+### Issue + PR Hygiene
+
+- Every non-trivial change should have an issue for context and acceptance criteria.
+- Every pull request should link an issue and include a clear test plan.
+- Pull requests should include focused review notes when the change has risk.
 
 ### Sentri Standards
 


### PR DESCRIPTION
## Summary
- add bug and feature issue templates
- add issue template config with docs contact link
- require issue-linked PR flow in contribution guide
- extend PR template with linked issue + test plan + review focus

## Linked Issue
Closes #21

## Testing
- docs and template-only change
- no runtime code changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added issue templates for bug reports and feature requests to streamline issue reporting
  * Updated contribution guidelines to require issues before non-trivial changes
  * Enhanced pull request template with test plan and review focus sections

* **Chores**
  * Configured GitHub issue template settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->