### PR TITLE
Cycle 2: backend upload pipeline hardening

### DIFF
--- a/backend/src/main/java/com/sentri/backend/config/TimetableUploadProperties.java
+++ b/backend/src/main/java/com/sentri/backend/config/TimetableUploadProperties.java
@@ -3,9 +3,17 @@ package com.sentri.backend.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "sentri.timetable.upload")
-public record TimetableUploadProperties(String storageDir) {
+public record TimetableUploadProperties(String storageDir, Long maxFileSizeBytes) {
+
+    private static final long DEFAULT_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
 
     public String resolvedStorageDir() {
         return storageDir == null || storageDir.isBlank() ? "./data/timetable-uploads" : storageDir;
+    }
+
+    public long resolvedMaxFileSizeBytes() {
+        return maxFileSizeBytes == null || maxFileSizeBytes <= 0
+                ? DEFAULT_MAX_FILE_SIZE_BYTES
+                : maxFileSizeBytes;
     }
 }

--- a/backend/src/main/java/com/sentri/backend/service/TimetableUploadStorageServiceImpl.java
+++ b/backend/src/main/java/com/sentri/backend/service/TimetableUploadStorageServiceImpl.java
@@ -11,18 +11,37 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
 public class TimetableUploadStorageServiceImpl implements TimetableUploadStorageService {
 
+    private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/webp"
+    );
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".webp"
+    );
+
     private final Path storageRoot;
+    private final long maxFileSizeBytes;
 
     public TimetableUploadStorageServiceImpl(TimetableUploadProperties properties) {
         this.storageRoot = Path.of(properties.resolvedStorageDir()).toAbsolutePath().normalize();
+        this.maxFileSizeBytes = properties.resolvedMaxFileSizeBytes();
     }
 
     @Override
@@ -30,9 +49,17 @@ public class TimetableUploadStorageServiceImpl implements TimetableUploadStorage
         if (file == null || file.isEmpty()) {
             throw new BadRequestException("A timetable screenshot is required");
         }
+        if (file.getSize() > maxFileSizeBytes) {
+            throw new BadRequestException("Uploaded screenshot exceeds size limit");
+        }
 
         String originalFilename = sanitizeFilename(file.getOriginalFilename());
         String extension = extractExtension(originalFilename);
+        String mimeType = normalizeMimeType(file.getContentType());
+        if (!isSupportedFile(extension, mimeType)) {
+            throw new BadRequestException("Only PNG/JPG/WEBP screenshot files are supported");
+        }
+
         String storageFilename = UUID.randomUUID() + extension;
         Path destination = storageRoot.resolve(storageFilename);
 
@@ -43,7 +70,7 @@ public class TimetableUploadStorageServiceImpl implements TimetableUploadStorage
             }
             return new StoredTimetableUpload(
                     originalFilename,
-                    file.getContentType(),
+                    mimeType,
                     sha256(destination),
                     destination.toString()
             );
@@ -62,13 +89,33 @@ public class TimetableUploadStorageServiceImpl implements TimetableUploadStorage
         if (lastDot < 0 || lastDot == filename.length() - 1) {
             return "";
         }
-        return filename.substring(lastDot);
+        return filename.substring(lastDot).toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizeMimeType(String mimeType) {
+        if (!StringUtils.hasText(mimeType)) {
+            return null;
+        }
+        String normalized = mimeType.toLowerCase(Locale.ROOT).trim();
+        int separatorIndex = normalized.indexOf(';');
+        return separatorIndex < 0 ? normalized : normalized.substring(0, separatorIndex).trim();
+    }
+
+    private boolean isSupportedFile(String extension, String mimeType) {
+        return ALLOWED_EXTENSIONS.contains(extension)
+                || (mimeType != null && ALLOWED_MIME_TYPES.contains(mimeType));
     }
 
     private String sha256(Path file) throws IOException {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            return HexFormat.of().formatHex(digest.digest(Files.readAllBytes(file)));
+            try (InputStream inputStream = new DigestInputStream(Files.newInputStream(file), digest)) {
+                byte[] buffer = new byte[8192];
+                while (inputStream.read(buffer) != -1) {
+                    // Stream file to digest without loading entire upload into memory.
+                }
+            }
+            return HexFormat.of().formatHex(digest.digest());
         } catch (NoSuchAlgorithmException exception) {
             throw new IllegalStateException("SHA-256 is not available", exception);
         }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,3 +25,4 @@ sentri:
   timetable:
     upload:
       storage-dir: ${SENTRI_TIMETABLE_UPLOAD_DIR:./data/timetable-uploads}
+      max-file-size-bytes: ${SENTRI_TIMETABLE_UPLOAD_MAX_FILE_SIZE_BYTES:5242880}

--- a/backend/src/test/java/com/sentri/backend/service/TimetableBatchServiceTest.java
+++ b/backend/src/test/java/com/sentri/backend/service/TimetableBatchServiceTest.java
@@ -203,4 +203,33 @@ class TimetableBatchServiceTest {
         assertThat(persisted.getSourceImageStoragePath()).isNotBlank();
         assertThat(Files.exists(Path.of(persisted.getSourceImageStoragePath()))).isTrue();
     }
+
+        @Test
+        void rejectsUploadBatchForUnsupportedFileType() {
+                MockMultipartFile file = new MockMultipartFile(
+                                "file",
+                                "week-13.txt",
+                                "text/plain",
+                                "not-an-image".getBytes()
+                );
+
+                assertThatThrownBy(() -> timetableBatchService.createUploadBatch(file, "test", null))
+                                .isInstanceOf(BadRequestException.class)
+                                .hasMessageContaining("Only PNG/JPG/WEBP screenshot files are supported");
+        }
+
+        @Test
+        void rejectsUploadBatchWhenFileIsTooLarge() {
+                byte[] oversized = new byte[2048];
+                MockMultipartFile file = new MockMultipartFile(
+                                "file",
+                                "week-13.png",
+                                "image/png",
+                                oversized
+                );
+
+                assertThatThrownBy(() -> timetableBatchService.createUploadBatch(file, "test", null))
+                                .isInstanceOf(BadRequestException.class)
+                                .hasMessageContaining("Uploaded screenshot exceeds size limit");
+        }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -15,3 +15,4 @@ sentri:
   timetable:
     upload:
       storage-dir: ${java.io.tmpdir}/sentri-test-uploads
+      max-file-size-bytes: 1024


### PR DESCRIPTION
## Summary
- enforce timetable upload max size in backend config and storage service
- validate supported screenshot mime and extension
- switch sha256 generation to streaming digest
- add tests for unsupported type and oversized uploads

## Linked Issue
Closes #25

## Testing
- mvn -q -Dtest=TimetableBatchServiceTest test
