### PR TITLE
Cycle 3: ML pipeline input resilience

### DIFF
--- a/ml-worker/src/sentri_worker/pipeline.py
+++ b/ml-worker/src/sentri_worker/pipeline.py
@@ -19,19 +19,7 @@ class SentriWorker:
         ocr_result = self.ocr_service.extract_from_payload(payload)
         raw_text = payload.get("ocr_text") or ocr_result.text or ""
 
-        cells_payload = payload.get("cells") or []
-        cells = [
-            OCRCell(
-                row=int(cell["row"]),
-                col=int(cell["col"]),
-                text=str(cell.get("text", "")),
-                row_span=int(cell.get("row_span", 1)),
-                col_span=int(cell.get("col_span", 1)),
-                confidence=cell.get("confidence"),
-            )
-            for cell in cells_payload
-            if isinstance(cell, dict)
-        ]
+        cells, payload_warnings = self._parse_cells(payload.get("cells"))
 
         result = parse_timetable(raw_text=raw_text, cells=cells, source=source)
         result.source["ocr"] = ocr_result.to_dict()
@@ -42,8 +30,15 @@ class SentriWorker:
                     for warning in ocr_result.warnings
                 ]
             )
+        if payload_warnings:
+            result.issues.extend(
+                [
+                    ParseIssue(code="payload_warning", message=warning)
+                    for warning in payload_warnings
+                ]
+            )
 
-        extraction_confidence = payload.get("extraction_confidence")
+        extraction_confidence = self._coerce_float(payload.get("extraction_confidence"))
         if extraction_confidence is None:
             confidences = [
                 float(cell.confidence)
@@ -51,9 +46,64 @@ class SentriWorker:
                 if cell.confidence is not None
             ]
             extraction_confidence = round(sum(confidences) / len(confidences), 4) if confidences else None
+        extraction_confidence = self._clamp_confidence(extraction_confidence)
 
         return result.to_backend_import_dict(
-            extraction_confidence=float(extraction_confidence)
-            if extraction_confidence is not None
-            else None
+            extraction_confidence=extraction_confidence
         )
+
+    def _parse_cells(self, cells_payload: Any) -> tuple[list[OCRCell], list[str]]:
+        if cells_payload is None:
+            return [], []
+        if not isinstance(cells_payload, list):
+            return [], ["Ignored cells payload because it is not a list."]
+
+        cells: list[OCRCell] = []
+        warnings: list[str] = []
+        for index, cell in enumerate(cells_payload):
+            if not isinstance(cell, dict):
+                warnings.append(f"Ignored non-object cell at index {index}.")
+                continue
+
+            row = self._coerce_int(cell.get("row"))
+            col = self._coerce_int(cell.get("col"))
+            if row is None or col is None:
+                warnings.append(f"Ignored cell at index {index} because row/col is missing or invalid.")
+                continue
+
+            row_span = self._coerce_int(cell.get("row_span"), default=1)
+            col_span = self._coerce_int(cell.get("col_span"), default=1)
+            confidence = self._coerce_float(cell.get("confidence"))
+            confidence = self._clamp_confidence(confidence)
+            cells.append(
+                OCRCell(
+                    row=row,
+                    col=col,
+                    text=str(cell.get("text", "")),
+                    row_span=max(row_span, 1),
+                    col_span=max(col_span, 1),
+                    confidence=confidence,
+                )
+            )
+        return cells, warnings
+
+    def _coerce_int(self, value: Any, default: int | None = None) -> int | None:
+        if value is None:
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _coerce_float(self, value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _clamp_confidence(self, value: float | None) -> float | None:
+        if value is None:
+            return None
+        return max(0.0, min(1.0, value))

--- a/ml-worker/tests/test_pipeline.py
+++ b/ml-worker/tests/test_pipeline.py
@@ -35,6 +35,45 @@ class PipelineTests(unittest.TestCase):
         self.assertEqual(result["rawOcrText"], payload["ocr_text"])
         self.assertEqual(result["metadata"]["sourceImageName"], "se_it_b_sem2.png")
 
+    def test_process_skips_invalid_cells_and_clamps_confidence(self) -> None:
+        payload = {
+            "source_name": "bad-cells.png",
+            "ocr_text": "Class: SE IT-B",
+            "extraction_confidence": "1.7",
+            "cells": [
+                {"row": 0, "col": 0, "text": "TIME/DAY"},
+                {"row": 0, "col": 1, "text": "8.45-9.45"},
+                {"row": 1, "col": 0, "text": "MON"},
+                {"row": 1, "col": 1, "text": "DBMS", "confidence": "0.8"},
+                {"row": "x", "col": 2, "text": "invalid-row"},
+                "not-a-dict",
+            ],
+        }
+
+        result = SentriWorker().process(payload)
+
+        self.assertEqual(result["extractionConfidence"], 1.0)
+        self.assertEqual(len(result["entries"]), 1)
+        self.assertIn("issue:payload_warning", result["metadata"]["sourceNotes"])
+
+    def test_process_uses_cell_confidence_average_when_payload_confidence_invalid(self) -> None:
+        payload = {
+            "source_name": "avg-confidence.png",
+            "ocr_text": "Class: SE IT-B",
+            "extraction_confidence": "not-a-number",
+            "cells": [
+                {"row": 0, "col": 0, "text": "TIME/DAY"},
+                {"row": 0, "col": 1, "text": "8.45-9.45"},
+                {"row": 1, "col": 0, "text": "MON"},
+                {"row": 1, "col": 1, "text": "DBMS", "confidence": 0.5},
+                {"row": 1, "col": 2, "text": "PM", "confidence": 0.9},
+            ],
+        }
+
+        result = SentriWorker().process(payload)
+
+        self.assertEqual(result["extractionConfidence"], 0.7)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- make worker cell parsing tolerant to malformed payload items
- skip invalid cells with structured payload warnings instead of crashing
- clamp extraction confidence to [0, 1]
- add pipeline tests for malformed payload and confidence fallback path

## Linked Issue
Closes #27

## Testing
- python3 -m unittest discover -s tests
