### PR TITLE
Cycle 4: ML parser consistency upgrades

### DIFF
--- a/ml-worker/src/sentri_worker/parser.py
+++ b/ml-worker/src/sentri_worker/parser.py
@@ -28,6 +28,16 @@ DAY_ALIASES = {
     "SUNDAY": "SUN",
 }
 
+DAY_ORDER = {
+    "MON": 1,
+    "TUE": 2,
+    "WED": 3,
+    "THU": 4,
+    "FRI": 5,
+    "SAT": 6,
+    "SUN": 7,
+}
+
 DAY_PATTERN = re.compile(r"\b(MON(?:DAY)?|TUE(?:S|SDAY)?|WED(?:NESDAY)?|THU(?:RS(?:DAY)?)?|FRI(?:DAY)?|SAT(?:URDAY)?|SUN(?:DAY)?)\b", re.IGNORECASE)
 TIME_PATTERN = re.compile(r"(?P<start>\d{1,2}(?:[:.]\d{2})?)\s*(?:-|–|to)\s*(?P<end>\d{1,2}(?:[:.]\d{2})?)", re.IGNORECASE)
 CLASS_PATTERN = re.compile(r"\b(?:Class|CLASS)\s*[:\-]\s*(?P<class>[A-Z0-9 &/-]+)", re.IGNORECASE)
@@ -308,6 +318,44 @@ def _span_times(time_map: dict[int, tuple[str | None, str | None]], start_col: i
     return columns[0][0], columns[-1][1]
 
 
+def _entry_sort_key(entry: TimetableEntry) -> tuple[int, int, int, int, int, str]:
+    start_minutes = _time_label_to_minutes(entry.start_time)
+    end_minutes = _time_label_to_minutes(entry.end_time)
+    return (
+        DAY_ORDER.get(entry.day_of_week, 99),
+        start_minutes if start_minutes is not None else 10_000,
+        end_minutes if end_minutes is not None else 10_001,
+        entry.source_row if entry.source_row is not None else 10_000,
+        entry.source_col if entry.source_col is not None else 10_000,
+        normalize_whitespace(entry.subject_text).upper(),
+    )
+
+
+def _deduplicate_entries(entries: Sequence[TimetableEntry], issues: list[ParseIssue]) -> list[TimetableEntry]:
+    deduplicated: list[TimetableEntry] = []
+    seen: set[tuple[str, str | None, str | None, str, str]] = set()
+
+    for entry in entries:
+        dedupe_key = (
+            entry.day_of_week,
+            entry.start_time,
+            entry.end_time,
+            normalize_whitespace(entry.subject_text).upper(),
+            entry.entry_type,
+        )
+        if dedupe_key in seen:
+            issues.append(
+                ParseIssue(
+                    code="duplicate_entry_removed",
+                    message=f"Removed duplicate entry for {entry.day_of_week} {entry.start_time or 'unknown'} {entry.subject_text}",
+                )
+            )
+            continue
+        seen.add(dedupe_key)
+        deduplicated.append(entry)
+    return deduplicated
+
+
 def parse_cells(cells: Sequence[OCRCell], raw_text: str = "", source: dict[str, object] | None = None) -> ParseResult:
     source = dict(source or {})
     issues: list[ParseIssue] = []
@@ -337,7 +385,7 @@ def parse_cells(cells: Sequence[OCRCell], raw_text: str = "", source: dict[str, 
         batch.image_path = str(source["image_path"])
 
     entries: list[TimetableEntry] = []
-    for cell in cells:
+    for cell in sorted(cells, key=lambda current: (current.row, current.col, current.row_span, current.col_span)):
         if cell.row == header_row or cell.col == day_col:
             continue
         raw_cell_text = cell.text.strip()
@@ -372,6 +420,8 @@ def parse_cells(cells: Sequence[OCRCell], raw_text: str = "", source: dict[str, 
                 col_span=cell.col_span,
             )
         )
+
+    entries = sorted(_deduplicate_entries(entries, issues), key=_entry_sort_key)
 
     if not entries and raw_text:
         issues.append(ParseIssue(code="no_entries_from_cells", message="No schedule entries were produced from the supplied cells."))
@@ -449,6 +499,8 @@ def parse_text_schedule(raw_text: str, source: dict[str, object] | None = None) 
                 raw_text=line,
             )
         )
+
+    entries = sorted(_deduplicate_entries(entries, issues), key=_entry_sort_key)
 
     if not entries:
         issues.append(ParseIssue(code="no_entries_from_text", message="Could not infer timetable entries from OCR text."))

--- a/ml-worker/tests/test_parser.py
+++ b/ml-worker/tests/test_parser.py
@@ -94,6 +94,28 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(result.entries[0].start_time, "08:45")
         self.assertEqual(result.entries[1].day_of_week, "TUE")
 
+    def test_parse_cells_is_deterministic_and_deduplicated(self) -> None:
+        cells = [
+            OCRCell(row=0, col=0, text="TIME/DAY"),
+            OCRCell(row=0, col=1, text="8.45-9.45"),
+            OCRCell(row=0, col=2, text="9.45-10.45"),
+            OCRCell(row=1, col=0, text="MON"),
+            OCRCell(row=1, col=2, text="PM\n(MA)"),
+            OCRCell(row=1, col=1, text="DBMS\n(VI)"),
+            OCRCell(row=1, col=1, text="DBMS\n(VI)"),
+        ]
+
+        result = parse_timetable(
+            raw_text="Class: SE IT-B\nAcademic Year - 2025-26 - SEM II",
+            cells=cells,
+        )
+
+        self.assertEqual(len(result.entries), 2)
+        self.assertEqual(result.entries[0].subject_text, "DBMS")
+        self.assertEqual(result.entries[0].start_time, "08:45")
+        self.assertEqual(result.entries[1].subject_text, "PM")
+        self.assertTrue(any(issue.code == "duplicate_entry_removed" for issue in result.issues))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add deterministic entry sorting for parser output
- remove duplicate timetable entries caused by OCR/table noise
- emit duplicate-removal parse issues for traceability
- add parser test for ordering and deduplication

## Linked Issue
Closes #29

## Testing
- python3 -m unittest discover -s tests
