### PR TITLE
Cycle 5: backend insight edge-case hardening

### DIFF
--- a/backend/src/main/java/com/sentri/backend/service/TimetableIntelligenceServiceImpl.java
+++ b/backend/src/main/java/com/sentri/backend/service/TimetableIntelligenceServiceImpl.java
@@ -56,7 +56,13 @@ public class TimetableIntelligenceServiceImpl implements TimetableIntelligenceSe
             );
         }
 
-        TimetableEntry holiday = entries.size() == 1 && Boolean.TRUE.equals(entries.get(0).getHolidayEntry()) ? entries.get(0) : null;
+        List<TimetableEntry> classEntries = entries.stream()
+            .filter(entry -> !Boolean.TRUE.equals(entry.getBreakEntry()) && !Boolean.TRUE.equals(entry.getHolidayEntry()))
+            .toList();
+
+        TimetableEntry holiday = classEntries.isEmpty()
+            ? entries.stream().filter(entry -> Boolean.TRUE.equals(entry.getHolidayEntry())).findFirst().orElse(null)
+            : null;
         if (holiday != null) {
             return new TimetableInsightResponse(
                     batch.getId(),
@@ -70,10 +76,23 @@ public class TimetableIntelligenceServiceImpl implements TimetableIntelligenceSe
             );
         }
 
-        int currentIndex = findCurrentIndex(entries, focusTime);
+        if (classEntries.isEmpty()) {
+            return new TimetableInsightResponse(
+                batch.getId(),
+                "empty",
+                "Nothing planned",
+                "No class sessions are available for this day.",
+                "upload_timetable",
+                resolveRefreshState(batch, focusDate),
+                null,
+                null
+            );
+        }
+
+        int currentIndex = findCurrentIndex(classEntries, focusTime);
         if (currentIndex >= 0) {
-            TimetableEntry current = entries.get(currentIndex);
-            TimetableEntry next = currentIndex + 1 < entries.size() ? entries.get(currentIndex + 1) : null;
+            TimetableEntry current = classEntries.get(currentIndex);
+            TimetableEntry next = currentIndex + 1 < classEntries.size() ? classEntries.get(currentIndex + 1) : null;
             long minutesLeft = current.getEndTime() == null ? 0 : Math.max(java.time.Duration.between(focusTime, current.getEndTime()).toMinutes(), 0);
 
             return new TimetableInsightResponse(
@@ -88,9 +107,9 @@ public class TimetableIntelligenceServiceImpl implements TimetableIntelligenceSe
             );
         }
 
-        int nextIndex = findNextIndex(entries, focusTime);
+        int nextIndex = findNextIndex(classEntries, focusTime);
         if (nextIndex >= 0) {
-            TimetableEntry next = entries.get(nextIndex);
+            TimetableEntry next = classEntries.get(nextIndex);
             long minutesUntil = next.getStartTime() == null ? 0 : Math.max(java.time.Duration.between(focusTime, next.getStartTime()).toMinutes(), 0);
 
             return new TimetableInsightResponse(

--- a/backend/src/test/java/com/sentri/backend/service/TimetableIntelligenceServiceTest.java
+++ b/backend/src/test/java/com/sentri/backend/service/TimetableIntelligenceServiceTest.java
@@ -62,6 +62,90 @@ class TimetableIntelligenceServiceTest {
         assertThat(insight.nextClass().title()).isEqualTo("DBMS");
     }
 
+    @Test
+    void skipsBreakEntriesWhenResolvingUpcomingClass() {
+        TimetableBatchDetailResponse created = timetableBatchService.createPlaceholderBatch(null);
+        TimetableBatchDetailResponse batch = timetableBatchService.saveParsedTimetable(created.id(), new ParsedTimetableImportRequest(
+                null,
+                "MON entries",
+                0.9,
+                List.of(
+                        new TimetableEntryRequest(
+                                "MON",
+                                LocalTime.of(8, 45),
+                                LocalTime.of(9, 0),
+                                "Morning Break",
+                                null,
+                                null,
+                                "BREAK",
+                                null,
+                                "BREAK row",
+                                1,
+                                true,
+                                false
+                        ),
+                        new TimetableEntryRequest(
+                                "MON",
+                                LocalTime.of(9, 0),
+                                LocalTime.of(9, 45),
+                                "DBMS",
+                                "Prof. Deshmukh",
+                                "LH 19",
+                                "LECTURE",
+                                null,
+                                "DBMS row",
+                                2,
+                                false,
+                                false
+                        )
+                )
+        ));
+
+        TimetableInsightResponse insight = timetableIntelligenceService.buildInsight(
+                batch.id(),
+                OffsetDateTime.of(2026, 3, 23, 8, 50, 0, 0, ZoneOffset.ofHoursMinutes(5, 30))
+        );
+
+        assertThat(insight.status()).isEqualTo("upcoming");
+        assertThat(insight.nextClass()).isNotNull();
+        assertThat(insight.nextClass().title()).isEqualTo("DBMS");
+    }
+
+    @Test
+    void returnsHolidayWhenOnlyHolidayEntryExists() {
+        TimetableBatchDetailResponse created = timetableBatchService.createPlaceholderBatch(null);
+        TimetableBatchDetailResponse batch = timetableBatchService.saveParsedTimetable(created.id(), new ParsedTimetableImportRequest(
+                null,
+                "MON holiday",
+                0.8,
+                List.of(
+                        new TimetableEntryRequest(
+                                "MON",
+                                null,
+                                null,
+                                "Festival Holiday",
+                                null,
+                                null,
+                                "HOLIDAY",
+                                "No classes",
+                                "HOLIDAY row",
+                                1,
+                                false,
+                                true
+                        )
+                )
+        ));
+
+        TimetableInsightResponse insight = timetableIntelligenceService.buildInsight(
+                batch.id(),
+                OffsetDateTime.of(2026, 3, 23, 10, 0, 0, 0, ZoneOffset.ofHoursMinutes(5, 30))
+        );
+
+        assertThat(insight.status()).isEqualTo("holiday");
+        assertThat(insight.headline()).isEqualTo("Festival Holiday");
+        assertThat(insight.nextClass()).isNull();
+    }
+
     private TimetableBatchDetailResponse createParsedBatch() {
         TimetableBatchDetailResponse created = timetableBatchService.createPlaceholderBatch(
                 new CreateTimetableBatchRequest(


### PR DESCRIPTION
## Summary
- exclude break and holiday entries from live/upcoming class selection
- preserve holiday state when schedule has only holiday entries
- add intelligence tests for break filtering and holiday-only behavior

## Linked Issue
Closes #31

## Testing
- mvn -q -Dtest=TimetableIntelligenceServiceTest test
