### PR TITLE
Deepen ML tuning profile for cleaner parser output

### DIFF
--- a/ml-worker/src/sentri_worker/parser.py
+++ b/ml-worker/src/sentri_worker/parser.py
@@ -70,7 +70,7 @@ WEF_PATTERN = re.compile(r"\b(?:WEF|Week Effective From)\s*[:\-]\s*(?P<date>.+)$
 PARENTHESES_CODE_PATTERN = re.compile(r"^\(([A-Z0-9]{1,6})\)$")
 FACULTY_CODE_PATTERN = re.compile(r"^(?:FACULTY|TEACHER|PROF)\s*[:\-]\s*([A-Z0-9]{2,8})$", re.IGNORECASE)
 LOCATION_PATTERN = re.compile(
-    r"\b(LAB(?:-[IVX\d]+)?|LIBRARY\s+[A-Z\d]+|TUT\s+ROOM|ROOM\s+[A-Z0-9-]+|CLASSROOM|LH\s*\d+|NGC|CGL|CR\s*[-:]?\s*\d+)\b",
+    r"\b(LAB(?:-?[IVX\d]+)?|LIBRARY\s+[A-Z\d]+|TUT\s+ROOM|ROOM\s+[A-Z0-9-]+|CLASSROOM|LH\s*\d+|NGC|CGL|CR\s*[-:]?\s*\d+)\b",
     re.IGNORECASE,
 )
 
@@ -305,8 +305,19 @@ def parse_cell_text(
                 faculty_code = long_code_match.group(1)
                 continue
 
+            if tuning_profile is not None:
+                tuned_code = tuning_profile.normalize_faculty_code(normalized_line)
+                if tuned_code and re.fullmatch(r"[A-Z0-9]{2,4}", tuned_code):
+                    faculty_code = tuned_code
+                    continue
+
             uppercase = re.sub(r"[^A-Z0-9]", "", normalized_line.upper())
-            if 2 <= len(uppercase) <= 6 and uppercase.isalnum() and " " not in normalized_line:
+            if (
+                2 <= len(uppercase) <= 4
+                and uppercase.isalnum()
+                and " " not in normalized_line
+                and not LOCATION_PATTERN.search(normalized_line)
+            ):
                 faculty_code = uppercase
                 continue
 

--- a/ml-worker/src/sentri_worker/parser.py
+++ b/ml-worker/src/sentri_worker/parser.py
@@ -318,6 +318,11 @@ def parse_cell_text(
         location_guess = next((normalize_subject_text(line, tuning_profile=tuning_profile) for line in lines if LOCATION_PATTERN.search(line)), None)
         if location_guess and location_guess != subject:
             location = location_guess
+
+    if tuning_profile is not None:
+        faculty_code = tuning_profile.normalize_faculty_code(faculty_code)
+        location = tuning_profile.normalize_location_label(location)
+
     return subject, faculty_code, location, _cleanup_notes(notes, subject, faculty_code, location)
 
 

--- a/ml-worker/src/sentri_worker/tuning.py
+++ b/ml-worker/src/sentri_worker/tuning.py
@@ -17,6 +17,14 @@ DEFAULT_SUBJECT_VOCABULARY = (
     "CALCULUS",
 )
 
+DEFAULT_SUBJECT_NOISE_TOKENS = (
+    "LECTURE",
+    "THEORY",
+    "SUBJECT",
+    "COURSE",
+    "PAPER",
+)
+
 DEFAULT_SUBJECT_ALIASES = {
     "DBM5": "DBMS",
     "D8MS": "DBMS",
@@ -49,12 +57,17 @@ class TuningProfile:
     subject_aliases: dict[str, str] | None = None
     faculty_aliases: dict[str, str] | None = None
     location_aliases: dict[str, str] | None = None
+    subject_noise_tokens: tuple[str, ...] = DEFAULT_SUBJECT_NOISE_TOKENS
     min_match_score: float = 0.83
 
     def normalize_subject(self, value: str) -> str:
         cleaned = " ".join(value.strip().split())
         if not cleaned:
             return cleaned
+
+        cleaned = self._strip_subject_noise(cleaned)
+        if not cleaned:
+            return ""
 
         aliases = self.subject_aliases or DEFAULT_SUBJECT_ALIASES
         upper_cleaned = cleaned.upper()
@@ -71,6 +84,11 @@ class TuningProfile:
             cutoff=max(0.0, min(1.0, self.min_match_score)),
         )
         return closest[0] if closest else cleaned
+
+    def _strip_subject_noise(self, value: str) -> str:
+        noise_tokens = {token.upper() for token in self.subject_noise_tokens}
+        words = [word for word in value.split() if word.upper() not in noise_tokens]
+        return " ".join(words)
 
     def normalize_faculty_code(self, value: str | None) -> str | None:
         if value is None:
@@ -115,6 +133,7 @@ def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
     aliases = tuning_payload.get("subject_aliases")
     faculty_aliases = tuning_payload.get("faculty_aliases")
     location_aliases = tuning_payload.get("location_aliases")
+    subject_noise_tokens = tuning_payload.get("subject_noise_tokens")
     min_match_score = tuning_payload.get("min_match_score")
 
     resolved_vocab = DEFAULT_SUBJECT_VOCABULARY
@@ -147,6 +166,12 @@ def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
             if key_text and value_text:
                 resolved_location_aliases[key_text] = value_text
 
+    resolved_subject_noise_tokens = DEFAULT_SUBJECT_NOISE_TOKENS
+    if isinstance(subject_noise_tokens, list):
+        normalized_noise_tokens = [str(token).strip().upper() for token in subject_noise_tokens if str(token).strip()]
+        if normalized_noise_tokens:
+            resolved_subject_noise_tokens = tuple(dict.fromkeys(normalized_noise_tokens))
+
     resolved_score = 0.83
     try:
         if min_match_score is not None:
@@ -159,5 +184,6 @@ def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
         subject_aliases=resolved_aliases,
         faculty_aliases=resolved_faculty_aliases,
         location_aliases=resolved_location_aliases,
+        subject_noise_tokens=resolved_subject_noise_tokens,
         min_match_score=max(0.0, min(1.0, resolved_score)),
     )

--- a/ml-worker/src/sentri_worker/tuning.py
+++ b/ml-worker/src/sentri_worker/tuning.py
@@ -28,11 +28,27 @@ DEFAULT_SUBJECT_ALIASES = {
     "P&S": "P & S",
 }
 
+DEFAULT_FACULTY_ALIASES = {
+    "M A": "MA",
+    "M.A": "MA",
+    "V1": "VI",
+    "S G": "SG",
+}
+
+DEFAULT_LOCATION_ALIASES = {
+    "LH2O": "LH 20",
+    "LH-20": "LH 20",
+    "LABIII": "LAB-III",
+    "LAB II": "LAB-II",
+}
+
 
 @dataclass(slots=True)
 class TuningProfile:
     subject_vocabulary: tuple[str, ...] = DEFAULT_SUBJECT_VOCABULARY
     subject_aliases: dict[str, str] | None = None
+    faculty_aliases: dict[str, str] | None = None
+    location_aliases: dict[str, str] | None = None
     min_match_score: float = 0.83
 
     def normalize_subject(self, value: str) -> str:
@@ -56,6 +72,38 @@ class TuningProfile:
         )
         return closest[0] if closest else cleaned
 
+    def normalize_faculty_code(self, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = " ".join(value.strip().upper().split())
+        if not cleaned:
+            return None
+
+        aliases = self.faculty_aliases or DEFAULT_FACULTY_ALIASES
+        if cleaned in aliases:
+            return aliases[cleaned]
+
+        compact = cleaned.replace(" ", "")
+        if compact in aliases:
+            return aliases[compact]
+        return compact
+
+    def normalize_location_label(self, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = " ".join(value.strip().upper().split())
+        if not cleaned:
+            return None
+
+        aliases = self.location_aliases or DEFAULT_LOCATION_ALIASES
+        if cleaned in aliases:
+            return aliases[cleaned]
+
+        compact = cleaned.replace(" ", "")
+        if compact in aliases:
+            return aliases[compact]
+        return cleaned
+
 
 def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
     payload = payload or {}
@@ -65,6 +113,8 @@ def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
 
     vocab = tuning_payload.get("subject_vocabulary")
     aliases = tuning_payload.get("subject_aliases")
+    faculty_aliases = tuning_payload.get("faculty_aliases")
+    location_aliases = tuning_payload.get("location_aliases")
     min_match_score = tuning_payload.get("min_match_score")
 
     resolved_vocab = DEFAULT_SUBJECT_VOCABULARY
@@ -81,6 +131,22 @@ def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
             if key_text and value_text:
                 resolved_aliases[key_text] = value_text
 
+    resolved_faculty_aliases: dict[str, str] = DEFAULT_FACULTY_ALIASES.copy()
+    if isinstance(faculty_aliases, dict):
+        for key, value in faculty_aliases.items():
+            key_text = str(key).strip().upper()
+            value_text = str(value).strip().upper()
+            if key_text and value_text:
+                resolved_faculty_aliases[key_text] = value_text
+
+    resolved_location_aliases: dict[str, str] = DEFAULT_LOCATION_ALIASES.copy()
+    if isinstance(location_aliases, dict):
+        for key, value in location_aliases.items():
+            key_text = str(key).strip().upper()
+            value_text = str(value).strip().upper()
+            if key_text and value_text:
+                resolved_location_aliases[key_text] = value_text
+
     resolved_score = 0.83
     try:
         if min_match_score is not None:
@@ -91,5 +157,7 @@ def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
     return TuningProfile(
         subject_vocabulary=resolved_vocab,
         subject_aliases=resolved_aliases,
+        faculty_aliases=resolved_faculty_aliases,
+        location_aliases=resolved_location_aliases,
         min_match_score=max(0.0, min(1.0, resolved_score)),
     )

--- a/ml-worker/tests/test_parser.py
+++ b/ml-worker/tests/test_parser.py
@@ -11,6 +11,7 @@ if str(SRC) not in sys.path:
 
 from sentri_worker.models import OCRCell
 from sentri_worker.parser import parse_cell_text, parse_timetable, parse_text_schedule
+from sentri_worker.tuning import TuningProfile
 
 
 class ParserTests(unittest.TestCase):
@@ -143,6 +144,24 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(faculty_code, "MA")
         self.assertEqual(location, "LH 20")
         self.assertEqual(notes, ["Revision"])
+
+    def test_parse_cell_text_applies_custom_tuning_profile(self) -> None:
+        tuning_profile = TuningProfile(
+            subject_aliases={"MATH5": "MATHS"},
+            faculty_aliases={"M 4": "MA"},
+            location_aliases={"LABIII": "LAB-III"},
+            subject_noise_tokens=("LECTURE",),
+        )
+
+        subject, faculty_code, location, notes = parse_cell_text(
+            "MATH5 LECTURE\nM 4\nLABIII\nPractice",
+            tuning_profile=tuning_profile,
+        )
+
+        self.assertEqual(subject, "MATHS")
+        self.assertEqual(faculty_code, "MA")
+        self.assertEqual(location, "LAB-III")
+        self.assertEqual(notes, ["Practice"])
 
 
 if __name__ == "__main__":

--- a/ml-worker/tests/test_tuning_evaluate.py
+++ b/ml-worker/tests/test_tuning_evaluate.py
@@ -22,6 +22,13 @@ class TuningAndEvaluateTests(unittest.TestCase):
                     "subject_aliases": {
                         "math5": "maths"
                     },
+                    "faculty_aliases": {
+                        "m 4": "ma"
+                    },
+                    "location_aliases": {
+                        "labiii": "lab-iii"
+                    },
+                    "subject_noise_tokens": ["lecture"],
                     "subject_vocabulary": ["MATHS", "DBMS"],
                     "min_match_score": 0.8,
                 }
@@ -29,7 +36,10 @@ class TuningAndEvaluateTests(unittest.TestCase):
         )
 
         self.assertEqual(profile.normalize_subject("math5"), "MATHS")
+        self.assertEqual(profile.normalize_subject("DBMS Lecture"), "DBMS")
         self.assertEqual(profile.normalize_subject("dbm5"), "DBMS")
+        self.assertEqual(profile.normalize_faculty_code("m 4"), "MA")
+        self.assertEqual(profile.normalize_location_label("labiii"), "LAB-III")
 
     def test_worker_applies_payload_tuning_to_subjects(self) -> None:
         worker = SentriWorker()


### PR DESCRIPTION
## Summary
- extend tuning profile with faculty and location normalization controls
- apply tuning normalization to parser extracted faculty/location fields
- add configurable subject noise-token cleanup
- add tests for advanced tuning behavior and parser disambiguation

## Linked Issue
Closes #41

## Testing
- cd ml-worker && python3 -m unittest discover -s tests
