### PR TITLE
Add reusable design-system primitives for cards and sheets

### DIFF
--- a/app/src/components/sentri-ui.tsx
+++ b/app/src/components/sentri-ui.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
+import type { ReactNode } from 'react';
 import { Modal, Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 import { theme, type TabKey } from '../design/tokens';
 
@@ -7,6 +8,26 @@ type CapsuleTabBarProps = {
   onTabChange: (tab: TabKey) => void;
   onSentriPress: () => void;
   tone?: 'light' | 'dark';
+};
+
+type SurfaceCardProps = {
+  children: ReactNode;
+  tone?: 'default' | 'alt' | 'accent' | 'dark';
+  radius?: 'md' | 'lg';
+  padded?: boolean;
+};
+
+type SectionHeaderProps = {
+  title: string;
+  meta?: string;
+  right?: ReactNode;
+};
+
+type SheetHeaderProps = {
+  eyebrow: string;
+  title: string;
+  actionLabel?: string;
+  onActionPress: () => void;
 };
 
 export function AvatarButton({
@@ -157,6 +178,49 @@ export function CapsuleTabBar({
           onPress={() => onTabChange('hangout')}
         />
       </View>
+    </View>
+  );
+}
+
+export function SurfaceCard({ children, tone = 'default', radius = 'lg', padded = true }: SurfaceCardProps) {
+  return (
+    <View
+      style={[
+        styles.surfaceCard,
+        radius === 'md' ? styles.surfaceCardMd : styles.surfaceCardLg,
+        padded && styles.surfaceCardPadded,
+        tone === 'alt' && styles.surfaceCardAlt,
+        tone === 'accent' && styles.surfaceCardAccent,
+        tone === 'dark' && styles.surfaceCardDark,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}
+
+export function SectionHeader({ title, meta, right }: SectionHeaderProps) {
+  return (
+    <View style={styles.sharedSectionHeader}>
+      <View style={styles.sharedSectionHeaderCopy}>
+        <Text style={styles.sharedSectionTitle}>{title}</Text>
+        {meta ? <Text style={styles.sharedSectionMeta}>{meta}</Text> : null}
+      </View>
+      {right}
+    </View>
+  );
+}
+
+export function SheetHeader({ eyebrow, title, actionLabel = 'Done', onActionPress }: SheetHeaderProps) {
+  return (
+    <View style={styles.sheetHeader}>
+      <View>
+        <Text style={styles.sheetHeaderEyebrow}>{eyebrow}</Text>
+        <Text style={styles.sheetHeaderTitle}>{title}</Text>
+      </View>
+      <Pressable onPress={onActionPress} style={styles.sheetHeaderButton}>
+        <Text style={styles.sheetHeaderButtonText}>{actionLabel}</Text>
+      </Pressable>
     </View>
   );
 }
@@ -347,6 +411,87 @@ const styles = StyleSheet.create({
     color: theme.colors.text,
     fontSize: 15,
     fontWeight: '600',
+  },
+  surfaceCard: {
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.line,
+    ...theme.shadow.soft,
+  },
+  surfaceCardMd: {
+    borderRadius: theme.radius.md,
+  },
+  surfaceCardLg: {
+    borderRadius: theme.radius.lg,
+  },
+  surfaceCardPadded: {
+    padding: 18,
+  },
+  surfaceCardAlt: {
+    backgroundColor: theme.colors.surfaceAlt,
+  },
+  surfaceCardAccent: {
+    backgroundColor: theme.colors.accentSoft,
+    borderColor: theme.colors.accentSoft,
+  },
+  surfaceCardDark: {
+    backgroundColor: theme.colors.darkSurface,
+    borderColor: theme.colors.darkLine,
+  },
+  sharedSectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing.md,
+  },
+  sharedSectionHeaderCopy: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: theme.spacing.xs,
+    flexWrap: 'wrap',
+    flex: 1,
+  },
+  sharedSectionTitle: {
+    color: theme.colors.text,
+    fontSize: 19,
+    fontWeight: '800',
+  },
+  sharedSectionMeta: {
+    color: theme.colors.textSoft,
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  sheetHeader: {
+    paddingHorizontal: theme.chrome.horizontalPadding,
+    paddingTop: 12,
+    paddingBottom: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  sheetHeaderEyebrow: {
+    color: theme.colors.accentStrong,
+    fontSize: 12,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  sheetHeaderTitle: {
+    marginTop: 6,
+    color: theme.colors.text,
+    fontSize: 28,
+    fontWeight: '800',
+  },
+  sheetHeaderButton: {
+    borderRadius: 16,
+    backgroundColor: theme.colors.surfaceAlt,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  sheetHeaderButtonText: {
+    color: theme.colors.text,
+    fontSize: 14,
+    fontWeight: '700',
   },
   tabWrap: {
     position: 'absolute',

--- a/app/src/screens/AccountSheet.tsx
+++ b/app/src/screens/AccountSheet.tsx
@@ -1,4 +1,5 @@
 import { Modal, Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SectionHeader, SheetHeader, SurfaceCard } from '../components/sentri-ui';
 import { theme } from '../design/tokens';
 import type { UserProfile } from '../types/auth';
 
@@ -28,18 +29,10 @@ export default function AccountSheet({
     <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
       <View style={styles.backdrop}>
         <SafeAreaView style={styles.safeArea}>
-          <View style={styles.header}>
-            <View>
-              <Text style={styles.eyebrow}>Account</Text>
-              <Text style={styles.title}>{viewMode === 'settings' ? 'Settings' : displayName}</Text>
-            </View>
-            <Pressable onPress={onClose} style={styles.closeButton}>
-              <Text style={styles.closeText}>Done</Text>
-            </Pressable>
-          </View>
+          <SheetHeader eyebrow="Account" title={viewMode === 'settings' ? 'Settings' : displayName} onActionPress={onClose} />
 
           <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-            <View style={styles.heroCard}>
+            <SurfaceCard>
               <Text style={styles.heroLabel}>Primary contact</Text>
               <Text style={styles.heroValue}>{primaryContact}</Text>
               <Text style={styles.heroBody}>
@@ -57,19 +50,19 @@ export default function AccountSheet({
                   <Text style={styles.heroTagText}>{profile.phone ? 'Phone login' : 'Email login'}</Text>
                 </View>
               </View>
-            </View>
+            </SurfaceCard>
 
-            <View style={styles.sectionCard}>
-              <Text style={styles.sectionTitle}>Profile details</Text>
+            <SurfaceCard>
+              <SectionHeader title="Profile details" />
               <DetailRow label="First name" value={profile.firstName} />
               <DetailRow label="Last name" value={profile.lastName} />
               <DetailRow label="Date of birth" value={profile.dob} />
               <DetailRow label="Phone" value={profile.phone || 'Not added'} />
               <DetailRow label="Email" value={profile.email || 'Not added'} />
-            </View>
+            </SurfaceCard>
 
-            <View style={styles.sectionCard}>
-              <Text style={styles.sectionTitle}>Access</Text>
+            <SurfaceCard>
+              <SectionHeader title="Access" />
               <DetailRow label="Login method" value={profile.phone ? 'Phone or email + password' : 'Email + password'} />
               <DetailRow label="Password" value={profile.password ? maskPassword(profile.password) : 'Stored securely on backend'} />
               <DetailRow
@@ -81,32 +74,32 @@ export default function AccountSheet({
                 value={profile.lastLoginAt ? formatDateTime(profile.lastLoginAt) : 'This device session is current'}
               />
               <DetailRow label="Account created" value={profile.createdAt ? formatDateTime(profile.createdAt) : 'Unknown'} />
-            </View>
+            </SurfaceCard>
 
             {viewMode === 'settings' ? (
-              <View style={styles.sectionCard}>
-                <Text style={styles.sectionTitle}>Settings</Text>
+              <SurfaceCard>
+                <SectionHeader title="Settings" />
                 <DetailRow label="Notifications" value="Weekly timetable reminder every Saturday" />
                 <DetailRow label="Storage" value="Myspace captures linked to this account" />
                 <DetailRow label="Privacy" value="Account data visible only to you" />
                 <DetailRow label="Login preference" value="Phone or email with password" />
-              </View>
+              </SurfaceCard>
             ) : (
-              <View style={styles.sectionCard}>
-                <Text style={styles.sectionTitle}>Settings snapshot</Text>
+              <SurfaceCard>
+                <SectionHeader title="Settings snapshot" />
                 <DetailRow label="Notifications" value="Weekly timetable reminder on Saturday" />
                 <DetailRow label="Storage" value="Myspace captures stay linked to this account" />
                 <DetailRow label="Privacy" value="Account data is visible only to you" />
-              </View>
+              </SurfaceCard>
             )}
 
-            <View style={styles.sectionCard}>
-              <Text style={styles.sectionTitle}>Sentri flow</Text>
+            <SurfaceCard>
+              <SectionHeader title="Sentri flow" />
               <DetailRow label="Home" value="Timetable, current class, next class, and weekly refresh" />
               <DetailRow label="Myspace" value="Search, save, and resurface screenshots, links, and notes" />
               <DetailRow label="Calorie" value="Body-goal setup, daily target, meals, burns, and cheat days" />
               <DetailRow label="Hangout" value="Create room, share link, join room, and meeting controls" />
-            </View>
+            </SurfaceCard>
 
             <Pressable onPress={onLogout} style={styles.logoutButton}>
               <Text style={styles.logoutButtonText}>Logout</Text>
@@ -153,50 +146,10 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  header: {
-    paddingHorizontal: theme.chrome.horizontalPadding,
-    paddingTop: 12,
-    paddingBottom: 10,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  eyebrow: {
-    color: theme.colors.accentStrong,
-    fontSize: 12,
-    fontWeight: '800',
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-  },
-  title: {
-    marginTop: 6,
-    color: theme.colors.text,
-    fontSize: 28,
-    fontWeight: '800',
-  },
-  closeButton: {
-    borderRadius: 16,
-    backgroundColor: theme.colors.surfaceAlt,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-  },
-  closeText: {
-    color: theme.colors.text,
-    fontSize: 14,
-    fontWeight: '700',
-  },
   content: {
     paddingHorizontal: theme.chrome.horizontalPadding,
     paddingBottom: 28,
     gap: 14,
-  },
-  heroCard: {
-    backgroundColor: theme.colors.surface,
-    borderRadius: 28,
-    borderWidth: 1,
-    borderColor: theme.colors.line,
-    padding: 18,
-    ...theme.shadow.soft,
   },
   heroLabel: {
     color: theme.colors.textSoft,
@@ -233,20 +186,6 @@ const styles = StyleSheet.create({
     color: theme.colors.accentStrong,
     fontSize: 12,
     fontWeight: '800',
-  },
-  sectionCard: {
-    backgroundColor: theme.colors.surface,
-    borderRadius: 24,
-    borderWidth: 1,
-    borderColor: theme.colors.line,
-    paddingHorizontal: 18,
-    paddingVertical: 14,
-  },
-  sectionTitle: {
-    color: theme.colors.text,
-    fontSize: 20,
-    fontWeight: '800',
-    marginBottom: 6,
   },
   detailRow: {
     paddingVertical: 12,

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import * as ImagePicker from 'expo-image-picker';
 import { ActivityIndicator, Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { AvatarButton } from '../components/sentri-ui';
+import { AvatarButton, SectionHeader, SurfaceCard } from '../components/sentri-ui';
 import { theme } from '../design/tokens';
 import { calendarTags } from '../features/home/timetable-fixtures';
 import {
@@ -341,11 +341,8 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
       ) : null}
 
       {recentUploads.length ? (
-        <View style={styles.uploadHistoryCard}>
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>Recent uploads</Text>
-            <Text style={styles.sectionAction}>{recentUploads.length} tracked</Text>
-          </View>
+        <SurfaceCard>
+          <SectionHeader title="Recent uploads" meta={`${recentUploads.length} tracked`} />
           {recentUploads.map((upload, index) => (
             <View key={upload.batchId} style={[styles.historyRow, index !== 0 && styles.historyRowBorder]}>
               <View style={styles.historyCopy}>
@@ -360,7 +357,7 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
               </View>
             </View>
           ))}
-        </View>
+        </SurfaceCard>
       ) : null}
 
       <View style={styles.segmentedControl}>
@@ -410,12 +407,7 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
             })}
           </ScrollView>
 
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>{timelineTitle}</Text>
-            <Text style={styles.sectionAction}>
-              {selectedEntries.length ? `${selectedEntries.length} items` : 'No items'}
-            </Text>
-          </View>
+          <SectionHeader title={timelineTitle} meta={selectedEntries.length ? `${selectedEntries.length} items` : 'No items'} />
 
           {selectedEntries.length ? (
             <View style={styles.scheduleCard}>
@@ -473,10 +465,7 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
 
       {viewMode === 'week' ? (
         <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>This week</Text>
-            <Text style={styles.sectionAction}>Tap a day</Text>
-          </View>
+          <SectionHeader title="This week" meta="Tap a day" />
           {weekDays.map((date) => {
             const entries = getEntriesForDate(date);
             return (
@@ -508,10 +497,7 @@ export default function HomeScreen({ onOpenDrawer, avatarLabel }: HomeScreenProp
 
       {viewMode === 'month' ? (
         <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>{formatMonthYear(focusedDate)}</Text>
-            <Text style={styles.sectionAction}>Tap a date</Text>
-          </View>
+          <SectionHeader title={formatMonthYear(focusedDate)} meta="Tap a date" />
 
           <View style={styles.weekdayRow}>
             {['M', 'T', 'W', 'T', 'F', 'S', 'S'].map((label, index) => (

--- a/app/src/screens/SentriSheet.tsx
+++ b/app/src/screens/SentriSheet.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Modal, Pressable, SafeAreaView, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { SectionHeader, SheetHeader, SurfaceCard } from '../components/sentri-ui';
 import { theme } from '../design/tokens';
 
 type SentriSheetProps = {
@@ -44,26 +45,18 @@ export default function SentriSheet({ visible, userName, onClose }: SentriSheetP
       <View style={styles.backdrop}>
         <Pressable style={styles.scrim} onPress={onClose} />
         <SafeAreaView style={styles.sheet}>
-          <View style={styles.header}>
-            <View>
-              <Text style={styles.eyebrow}>Sentri</Text>
-              <Text style={styles.title}>Your student copilot</Text>
-            </View>
-            <Pressable style={styles.doneButton} onPress={onClose}>
-              <Text style={styles.doneText}>Done</Text>
-            </Pressable>
-          </View>
+          <SheetHeader eyebrow="Sentri" title="Your student copilot" onActionPress={onClose} />
 
           <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-            <View style={styles.heroCard}>
+            <SurfaceCard tone="accent">
               <Text style={styles.heroTitle}>Hi {userName.split(' ')[0]}, Sentri is staged for your student tasks.</Text>
               <Text style={styles.heroBody}>
                 The assistant surface is ready in the navigation flow. Next we can wire it to timetable, Myspace, calorie, and hangout context.
               </Text>
-            </View>
+            </SurfaceCard>
 
             <View style={styles.section}>
-              <Text style={styles.sectionTitle}>Try asking later</Text>
+              <SectionHeader title="Try asking later" />
               {starterPrompts.map((prompt) => (
                 <Pressable
                   key={prompt}
@@ -78,7 +71,7 @@ export default function SentriSheet({ visible, userName, onClose }: SentriSheetP
               ))}
             </View>
 
-            <View style={styles.composerCard}>
+            <SurfaceCard>
               <Text style={styles.composerLabel}>Assistant input</Text>
               <TextInput
                 value={draft}
@@ -109,13 +102,13 @@ export default function SentriSheet({ visible, userName, onClose }: SentriSheetP
               <View style={styles.helperRow}>
                 <Text style={styles.helperText}>Voice and context-aware answers can plug in here next.</Text>
               </View>
-            </View>
+            </SurfaceCard>
 
             {reply ? (
-              <View style={styles.replyCard}>
+              <SurfaceCard radius="md">
                 <Text style={styles.replyLabel}>Sentri reply</Text>
                 <Text style={styles.replyText}>{reply}</Text>
-              </View>
+              </SurfaceCard>
             ) : null}
           </ScrollView>
         </SafeAreaView>
@@ -141,46 +134,10 @@ const styles = StyleSheet.create({
     backgroundColor: theme.colors.background,
     paddingTop: 10,
   },
-  header: {
-    paddingHorizontal: theme.chrome.horizontalPadding,
-    paddingBottom: 10,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  eyebrow: {
-    color: theme.colors.accentStrong,
-    fontSize: 12,
-    fontWeight: '800',
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-  },
-  title: {
-    marginTop: 6,
-    color: theme.colors.text,
-    fontSize: 26,
-    fontWeight: '800',
-  },
-  doneButton: {
-    borderRadius: 16,
-    backgroundColor: theme.colors.surfaceAlt,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-  },
-  doneText: {
-    color: theme.colors.text,
-    fontSize: 14,
-    fontWeight: '700',
-  },
   content: {
     paddingHorizontal: theme.chrome.horizontalPadding,
     paddingBottom: 28,
     gap: 14,
-  },
-  heroCard: {
-    backgroundColor: theme.colors.accentSoft,
-    borderRadius: 24,
-    padding: 18,
   },
   heroTitle: {
     color: theme.colors.text,
@@ -197,11 +154,6 @@ const styles = StyleSheet.create({
   section: {
     gap: 10,
   },
-  sectionTitle: {
-    color: theme.colors.text,
-    fontSize: 18,
-    fontWeight: '800',
-  },
   promptCard: {
     borderRadius: 18,
     backgroundColor: theme.colors.surface,
@@ -215,13 +167,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     lineHeight: 20,
-  },
-  composerCard: {
-    borderRadius: 24,
-    backgroundColor: theme.colors.surface,
-    borderWidth: 1,
-    borderColor: theme.colors.line,
-    padding: 18,
   },
   composerLabel: {
     color: theme.colors.textSoft,


### PR DESCRIPTION
## Summary
- add shared surface, section, and sheet header primitives to the Sentri UI layer
- adopt the shared sheet/card primitives in Account and Sentri sheets
- replace repeated Home section header markup with the shared section primitive

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized UI component architecture across screens using reusable card, section header, and sheet header components.
  * Consolidated redundant styling patterns to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->