### PR TITLE
Adopt shared section primitives in Myspace and Hangout

### DIFF
--- a/app/src/screens/HangoutScreen.tsx
+++ b/app/src/screens/HangoutScreen.tsx
@@ -11,7 +11,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { AvatarButton } from '../components/sentri-ui';
+import { AvatarButton, SectionHeader } from '../components/sentri-ui';
 import { theme } from '../design/tokens';
 import { PERSISTENT_KEYS } from '../lib/persistent-keys';
 import { usePersistedState } from '../lib/use-persisted-state';
@@ -640,14 +640,14 @@ export default function HangoutScreen({
         ) : null}
 
         <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>Live rooms</Text>
-            <Pressable onPress={() => void refreshRooms()}>
-              <Text style={styles.sectionMeta}>
-                {loadingAction === 'refreshing' ? 'Refreshing…' : 'Refresh'}
-              </Text>
-            </Pressable>
-          </View>
+          <SectionHeader
+            title="Live rooms"
+            right={
+              <Pressable onPress={() => void refreshRooms()}>
+                <Text style={styles.sectionMeta}>{loadingAction === 'refreshing' ? 'Refreshing…' : 'Refresh'}</Text>
+              </Pressable>
+            }
+          />
           {loadingAction === 'refreshing' && rooms.length === 0 ? (
             <View style={styles.emptyRooms}>
               <Text style={styles.emptyRoomsTitle}>Refreshing room list</Text>
@@ -684,10 +684,7 @@ export default function HangoutScreen({
         </View>
 
         <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>Friends</Text>
-            <Text style={styles.sectionMeta}>Invite list</Text>
-          </View>
+          <SectionHeader title="Friends" meta="Invite list" />
           {friends.map((friend) => (
             <View key={friend.name} style={styles.friendRow}>
               <View style={styles.friendLeft}>

--- a/app/src/screens/MyspaceScreen.tsx
+++ b/app/src/screens/MyspaceScreen.tsx
@@ -11,7 +11,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { AvatarButton } from '../components/sentri-ui';
+import { AvatarButton, SectionHeader } from '../components/sentri-ui';
 import { theme } from '../design/tokens';
 import { buildCapturedItem, buildCapturePreview, createEmptyCaptureDraft, type CaptureDraft } from '../features/myspace/capture-builder';
 import type { CaptureOption, SavedItem } from '../features/myspace/models';
@@ -208,10 +208,7 @@ export default function MyspaceScreen({ onOpenDrawer, avatarLabel }: MyspaceScre
         {!emptySearch ? (
           <>
             <View style={styles.section}>
-              <View style={styles.sectionHeader}>
-                <Text style={styles.sectionTitle}>Pinned</Text>
-                <Text style={styles.sectionMeta}>{pinnedItems.length}</Text>
-              </View>
+              <SectionHeader title="Pinned" meta={`${pinnedItems.length}`} />
 
               {pinnedItems.length ? (
                 <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.pinnedRow}>
@@ -233,10 +230,7 @@ export default function MyspaceScreen({ onOpenDrawer, avatarLabel }: MyspaceScre
 
             {recentTodayItems.length ? (
               <View style={styles.section}>
-                <View style={styles.sectionHeader}>
-                  <Text style={styles.sectionTitle}>New today</Text>
-                  <Text style={styles.sectionMeta}>{recentTodayItems.length}</Text>
-                </View>
+                <SectionHeader title="New today" meta={`${recentTodayItems.length}`} />
                 <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.pinnedRow}>
                   {recentTodayItems.map((item) => (
                     <PinnedCard key={`today-${item.id}`} item={item} onPress={() => setSelectedItem(item)} />
@@ -246,10 +240,7 @@ export default function MyspaceScreen({ onOpenDrawer, avatarLabel }: MyspaceScre
             ) : null}
 
             <View style={styles.section}>
-              <View style={styles.sectionHeader}>
-                <Text style={styles.sectionTitle}>Others</Text>
-                <Text style={styles.sectionMeta}>{otherItems.length}</Text>
-              </View>
+              <SectionHeader title="Others" meta={`${otherItems.length}`} />
 
               {otherItems.length ? (
                 <View style={styles.masonry}>


### PR DESCRIPTION
## Summary
- replace repeated Myspace section header markup with the shared primitive
- replace repeated Hangout section header markup with the shared primitive
- keep layout behavior unchanged while reducing style drift across tabs

Closes #47