### PR TITLE
parser: improve time/day normalization and text-split robustness

### DIFF
--- a/ml-worker/src/sentri_worker/parser.py
+++ b/ml-worker/src/sentri_worker/parser.py
@@ -194,7 +194,13 @@ def normalize_time_range(value: str) -> tuple[str | None, str | None] | None:
 
 
 def split_lines(raw_text: str) -> list[str]:
-    return [normalize_whitespace(line) for line in raw_text.splitlines() if normalize_whitespace(line)]
+    lines = [normalize_whitespace(line) for line in raw_text.splitlines() if normalize_whitespace(line)]
+    # Remove adjacent duplicate lines (common OCR doubling artifact)
+    deduplicated: list[str] = []
+    for line in lines:
+        if not deduplicated or line != deduplicated[-1]:
+            deduplicated.append(line)
+    return deduplicated
 
 
 def parse_date_value(value: str) -> str | None:

--- a/ml-worker/src/sentri_worker/parser.py
+++ b/ml-worker/src/sentri_worker/parser.py
@@ -115,6 +115,19 @@ def normalize_time_label(value: str) -> str | None:
     value = value.replace(" ", "")
     if not value:
         return None
+
+    # Handle am/pm suffix (e.g. "9am", "9:45pm", "9:45AM")
+    am_pm_match = re.match(r"^(\d{1,2}(?::\d{2})?)([AaPp][Mm])$", value)
+    if am_pm_match:
+        time_part, meridiem = am_pm_match.group(1), am_pm_match.group(2).upper()
+        if ":" not in time_part:
+            time_part = f"{time_part}:00"
+        try:
+            parsed = datetime.strptime(f"{time_part} {meridiem}", "%I:%M %p")
+            return parsed.strftime("%H:%M")
+        except ValueError:
+            pass
+
     if ":" not in value:
         if len(value) in {3, 4}:
             value = f"{value[:-2]}:{value[-2:]}"

--- a/ml-worker/src/sentri_worker/parser.py
+++ b/ml-worker/src/sentri_worker/parser.py
@@ -420,7 +420,10 @@ def _find_header_row(cells: Sequence[OCRCell]) -> int | None:
             score_by_row[cell.row] += 1
     if not score_by_row:
         return None
-    return score_by_row.most_common(1)[0][0]
+    max_score = max(score_by_row.values())
+    # Among all rows with the top score, prefer the lowest row index for determinism
+    candidates = [row for row, score in score_by_row.items() if score == max_score]
+    return min(candidates)
 
 
 def _find_day_col(cells: Sequence[OCRCell]) -> int | None:

--- a/ml-worker/tests/test_parser.py
+++ b/ml-worker/tests/test_parser.py
@@ -44,6 +44,21 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(normalize_time_label("12pm"), "12:00")
         self.assertEqual(normalize_time_label("12am"), "00:00")
 
+    def test_find_header_row_tie_breaks_on_lowest_row(self) -> None:
+        # Two rows have equal time-slot counts; the lower row index must win.
+        cells = [
+            OCRCell(row=0, col=1, text="8:00-9:00"),
+            OCRCell(row=0, col=2, text="9:00-10:00"),
+            OCRCell(row=2, col=1, text="8:00-9:00"),
+            OCRCell(row=2, col=2, text="9:00-10:00"),
+            OCRCell(row=1, col=0, text="MON"),
+        ]
+        result = parse_timetable(cells=cells)
+        # Header should be row 0, not row 2 — entries only come from rows != header
+        # If row 2 were picked as header, no day rows would exist and entries would be empty
+        # Row 0 as header means row 1 (MON) and row 2 produce day entries
+        self.assertEqual(result.cells_count, len(cells))
+
     def test_parse_header_metadata_from_text(self) -> None:
         raw_text = "\n".join(
             [

--- a/ml-worker/tests/test_parser.py
+++ b/ml-worker/tests/test_parser.py
@@ -10,7 +10,7 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from sentri_worker.models import OCRCell
-from sentri_worker.parser import classify_entry, parse_cell_text, parse_date_value, parse_timetable, parse_text_schedule
+from sentri_worker.parser import classify_entry, normalize_time_label, parse_cell_text, parse_date_value, parse_timetable, parse_text_schedule
 from sentri_worker.tuning import TuningProfile
 
 
@@ -36,6 +36,13 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(classify_entry("lunch"), "break")
         self.assertEqual(classify_entry("Practical"), "lab")
         self.assertEqual(classify_entry("PRACTICAL EXAM"), "lab")
+
+    def test_normalize_time_label_am_pm_suffix(self) -> None:
+        self.assertEqual(normalize_time_label("9am"), "09:00")
+        self.assertEqual(normalize_time_label("9AM"), "09:00")
+        self.assertEqual(normalize_time_label("9:45pm"), "21:45")
+        self.assertEqual(normalize_time_label("12pm"), "12:00")
+        self.assertEqual(normalize_time_label("12am"), "00:00")
 
     def test_parse_header_metadata_from_text(self) -> None:
         raw_text = "\n".join(

--- a/ml-worker/tests/test_parser.py
+++ b/ml-worker/tests/test_parser.py
@@ -10,7 +10,7 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from sentri_worker.models import OCRCell
-from sentri_worker.parser import classify_entry, normalize_time_label, parse_cell_text, parse_date_value, parse_timetable, parse_text_schedule
+from sentri_worker.parser import classify_entry, normalize_time_label, parse_cell_text, parse_date_value, parse_timetable, parse_text_schedule, split_lines
 from sentri_worker.tuning import TuningProfile
 
 
@@ -58,6 +58,14 @@ class ParserTests(unittest.TestCase):
         # If row 2 were picked as header, no day rows would exist and entries would be empty
         # Row 0 as header means row 1 (MON) and row 2 produce day entries
         self.assertEqual(result.cells_count, len(cells))
+
+    def test_split_lines_removes_adjacent_duplicates(self) -> None:
+        raw = "MON\nMON\nDBMS\nDBMS\nFRI"
+        self.assertEqual(split_lines(raw), ["MON", "DBMS", "FRI"])
+
+    def test_split_lines_keeps_non_adjacent_duplicates(self) -> None:
+        raw = "MON\nDBMS\nMON"
+        self.assertEqual(split_lines(raw), ["MON", "DBMS", "MON"])
 
     def test_parse_header_metadata_from_text(self) -> None:
         raw_text = "\n".join(


### PR DESCRIPTION
Closes #49

## Changes

- normalize_time_label: handle am/pm suffix inputs (9am → 09:00, 9:45pm → 21:45)
- _find_header_row: tie-break by lowest row index for deterministic header detection
- split_lines: deduplicate adjacent identical lines to handle OCR doubling artifact

All 26 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for 12-hour time format with AM/PM suffix (e.g., 9:00am, 9:45pm).

* **Bug Fixes**
  * Fixed OCR text duplication artifacts where identical consecutive lines were incorrectly processed.
  * Improved timetable header row detection for more consistent parsing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->