### PR TITLE
tuning+evaluate: extend_vocabulary, entry_type_counts, TuningProfile.merge

### DIFF
--- a/ml-worker/src/sentri_worker/evaluate.py
+++ b/ml-worker/src/sentri_worker/evaluate.py
@@ -150,11 +150,15 @@ def _build_per_day_metrics(
 ) -> dict[str, dict[str, Any]]:
     expected_by_day: dict[str, set[str]] = {}
     predicted_by_day: dict[str, set[str]] = {}
+    predicted_type_by_day: dict[str, list[str]] = {}
 
     for entry in expected_entries:
         expected_by_day.setdefault(entry["dayOfWeek"], set()).add(entry["_key"])
     for entry in predicted_entries:
         predicted_by_day.setdefault(entry["dayOfWeek"], set()).add(entry["_key"])
+        predicted_type_by_day.setdefault(entry["dayOfWeek"], []).append(
+            str(entry.get("entryType") or "lecture")
+        )
 
     days = sorted(set(expected_by_day.keys()) | set(predicted_by_day.keys()))
     metrics: dict[str, dict[str, Any]] = {}
@@ -168,6 +172,10 @@ def _build_per_day_metrics(
         recall = round(len(matched) / expected_count, 4) if expected_count else 0.0
         f1 = round((2 * precision * recall) / (precision + recall), 4) if (precision + recall) > 0 else 0.0
 
+        type_counts: dict[str, int] = {}
+        for entry_type in predicted_type_by_day.get(day, []):
+            type_counts[entry_type] = type_counts.get(entry_type, 0) + 1
+
         metrics[day] = {
             "matched": len(matched),
             "expected": expected_count,
@@ -175,6 +183,7 @@ def _build_per_day_metrics(
             "precision": precision,
             "recall": recall,
             "f1": f1,
+            "entry_type_counts": type_counts,
         }
     return metrics
 

--- a/ml-worker/src/sentri_worker/tuning.py
+++ b/ml-worker/src/sentri_worker/tuning.py
@@ -122,6 +122,40 @@ class TuningProfile:
             return aliases[compact]
         return cleaned
 
+    def merge(self, other: "TuningProfile") -> "TuningProfile":
+        """Return a new TuningProfile combining self (base) with other (overrides).
+
+        - subject_vocabulary: other's entries are appended after self's (deduplicated)
+        - aliases: other's entries override self's for matching keys
+        - min_match_score: other's value takes precedence
+        - subject_noise_tokens: merged (deduplicated, other appended)
+        """
+        merged_vocab = tuple(
+            dict.fromkeys(list(self.subject_vocabulary) + list(other.subject_vocabulary))
+        )
+
+        base_aliases = dict(self.subject_aliases or DEFAULT_SUBJECT_ALIASES)
+        base_aliases.update(other.subject_aliases or DEFAULT_SUBJECT_ALIASES)
+
+        base_faculty = dict(self.faculty_aliases or DEFAULT_FACULTY_ALIASES)
+        base_faculty.update(other.faculty_aliases or DEFAULT_FACULTY_ALIASES)
+
+        base_location = dict(self.location_aliases or DEFAULT_LOCATION_ALIASES)
+        base_location.update(other.location_aliases or DEFAULT_LOCATION_ALIASES)
+
+        merged_noise = tuple(
+            dict.fromkeys(list(self.subject_noise_tokens) + list(other.subject_noise_tokens))
+        )
+
+        return TuningProfile(
+            subject_vocabulary=merged_vocab,
+            subject_aliases=base_aliases,
+            faculty_aliases=base_faculty,
+            location_aliases=base_location,
+            subject_noise_tokens=merged_noise,
+            min_match_score=other.min_match_score,
+        )
+
 
 def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
     payload = payload or {}

--- a/ml-worker/src/sentri_worker/tuning.py
+++ b/ml-worker/src/sentri_worker/tuning.py
@@ -130,6 +130,7 @@ def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
         return TuningProfile()
 
     vocab = tuning_payload.get("subject_vocabulary")
+    extend_vocab = tuning_payload.get("extend_vocabulary")
     aliases = tuning_payload.get("subject_aliases")
     faculty_aliases = tuning_payload.get("faculty_aliases")
     location_aliases = tuning_payload.get("location_aliases")
@@ -141,6 +142,11 @@ def load_tuning_profile(payload: dict[str, Any] | None) -> TuningProfile:
         normalized_vocab = [str(item).strip().upper() for item in vocab if str(item).strip()]
         if normalized_vocab:
             resolved_vocab = tuple(dict.fromkeys(normalized_vocab))
+    elif isinstance(extend_vocab, list):
+        # Append to the default vocabulary without replacing it
+        extra = [str(item).strip().upper() for item in extend_vocab if str(item).strip()]
+        if extra:
+            resolved_vocab = tuple(dict.fromkeys(list(DEFAULT_SUBJECT_VOCABULARY) + extra))
 
     resolved_aliases: dict[str, str] = DEFAULT_SUBJECT_ALIASES.copy()
     if isinstance(aliases, dict):

--- a/ml-worker/tests/test_tuning_evaluate.py
+++ b/ml-worker/tests/test_tuning_evaluate.py
@@ -65,6 +65,14 @@ class TuningAndEvaluateTests(unittest.TestCase):
         self.assertIn("MATHS", profile.subject_vocabulary)
         self.assertIn("DATA STRUCTURES", profile.subject_vocabulary)
 
+    def test_per_day_metrics_include_entry_type_counts(self) -> None:
+        fixture_path = ROOT / "tests" / "fixtures" / "parser_eval_fixture.json"
+        report = evaluate_fixture_file(fixture_path)
+        per_day = report["metrics"]["per_day"]
+        for day_metrics in per_day.values():
+            self.assertIn("entry_type_counts", day_metrics)
+            self.assertIsInstance(day_metrics["entry_type_counts"], dict)
+
     def test_worker_applies_payload_tuning_to_subjects(self) -> None:
         worker = SentriWorker()
         payload = {

--- a/ml-worker/tests/test_tuning_evaluate.py
+++ b/ml-worker/tests/test_tuning_evaluate.py
@@ -51,6 +51,20 @@ class TuningAndEvaluateTests(unittest.TestCase):
         self.assertEqual(profile.normalize_faculty_code("m 4"), "MA")
         self.assertEqual(profile.normalize_location_label("labiii"), "LAB-III")
 
+    def test_load_tuning_profile_extend_vocabulary_appends_to_defaults(self) -> None:
+        profile = load_tuning_profile(
+            {
+                "tuning": {
+                    "extend_vocabulary": ["MATHS", "DATA STRUCTURES"],
+                }
+            }
+        )
+        # Default vocab entries must still be present
+        self.assertIn("DBMS", profile.subject_vocabulary)
+        # Extended entries must also be present
+        self.assertIn("MATHS", profile.subject_vocabulary)
+        self.assertIn("DATA STRUCTURES", profile.subject_vocabulary)
+
     def test_worker_applies_payload_tuning_to_subjects(self) -> None:
         worker = SentriWorker()
         payload = {

--- a/ml-worker/tests/test_tuning_evaluate.py
+++ b/ml-worker/tests/test_tuning_evaluate.py
@@ -11,7 +11,7 @@ if str(SRC) not in sys.path:
 
 from sentri_worker.evaluate import evaluate_fixture, evaluate_fixture_directory, evaluate_fixture_file
 from sentri_worker.pipeline import SentriWorker
-from sentri_worker.tuning import load_tuning_profile
+from sentri_worker.tuning import load_tuning_profile, TuningProfile
 
 
 class TuningAndEvaluateTests(unittest.TestCase):
@@ -72,6 +72,26 @@ class TuningAndEvaluateTests(unittest.TestCase):
         for day_metrics in per_day.values():
             self.assertIn("entry_type_counts", day_metrics)
             self.assertIsInstance(day_metrics["entry_type_counts"], dict)
+
+    def test_tuning_profile_merge_combines_vocab_and_aliases(self) -> None:
+        base = TuningProfile(
+            subject_vocabulary=("DBMS", "OS"),
+            subject_aliases={"DBM5": "DBMS"},
+            min_match_score=0.80,
+        )
+        override = TuningProfile(
+            subject_vocabulary=("MATHS",),
+            subject_aliases={"M4THS": "MATHS"},
+            min_match_score=0.90,
+        )
+        merged = base.merge(override)
+
+        self.assertIn("DBMS", merged.subject_vocabulary)
+        self.assertIn("OS", merged.subject_vocabulary)
+        self.assertIn("MATHS", merged.subject_vocabulary)
+        self.assertIn("DBM5", (merged.subject_aliases or {}))
+        self.assertIn("M4THS", (merged.subject_aliases or {}))
+        self.assertAlmostEqual(merged.min_match_score, 0.90)
 
     def test_worker_applies_payload_tuning_to_subjects(self) -> None:
         worker = SentriWorker()


### PR DESCRIPTION
Closes #51

## Changes

- tuning: support `extend_vocabulary` key in config to append subjects to default vocab
- evaluate: add `entry_type_counts` breakdown to per-day metrics in evaluation reports
- tuning: add `TuningProfile.merge()` to combine two profiles (custom overrides base)

All 29 tests pass.