### PR TITLE
Add Dockerized SQL runtime

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+target
+.m2
+.idea
+*.iml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,17 @@
+FROM maven:3.9.11-eclipse-temurin-17 AS build
+
+WORKDIR /workspace
+COPY pom.xml .
+RUN mvn -q -B dependency:go-offline
+
+COPY src src
+RUN mvn -q -B -DskipTests package
+
+FROM eclipse-temurin:17-jre
+
+WORKDIR /app
+COPY --from=build /workspace/target/*.jar /app/sentri-backend.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/sentri-backend.jar"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -32,6 +32,21 @@ Run tests:
 mvn test
 ```
 
+## Run with Docker
+
+From the repo root:
+
+```bash
+docker compose up --build
+```
+
+This starts:
+
+- `postgres` on `localhost:5432`
+- `sentri-backend` on `localhost:8080`
+
+The backend container uses the same PostgreSQL schema and upload storage paths as local development.
+
 ## API
 
 Base path: `/api/v1`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: sentri-postgres
+    environment:
+      POSTGRES_DB: sentri
+      POSTGRES_USER: sentri
+      POSTGRES_PASSWORD: sentri
+    ports:
+      - "5432:5432"
+    volumes:
+      - sentri-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sentri -d sentri"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: sentri-backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      SENTRI_DATABASE_URL: jdbc:postgresql://postgres:5432/sentri
+      SENTRI_DATABASE_USERNAME: sentri
+      SENTRI_DATABASE_PASSWORD: sentri
+      SENTRI_TIMETABLE_UPLOAD_DIR: /app/data/timetable-uploads
+    ports:
+      - "8080:8080"
+    volumes:
+      - sentri-backend-data:/app/data
+
+volumes:
+  sentri-postgres-data:
+  sentri-backend-data:


### PR DESCRIPTION
Closes #60

## Summary
- add Dockerfile for the Spring Boot backend
- add docker-compose for PostgreSQL and backend
- document Docker startup in the backend README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker support with multi-stage build configuration for the backend application.
  * Added Docker Compose configuration to run the backend and PostgreSQL services together.
  * Updated documentation with Docker-based startup instructions and service endpoint information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->