### PR TITLE
Expand SQL Myspace REST APIs

### DIFF
--- a/backend/src/main/java/com/sentri/backend/controller/MyspaceItemController.java
+++ b/backend/src/main/java/com/sentri/backend/controller/MyspaceItemController.java
@@ -1,7 +1,13 @@
 package com.sentri.backend.controller;
 
+import com.sentri.backend.dto.request.BulkUpsertMyspaceItemsRequest;
+import com.sentri.backend.dto.request.MyspaceSearchRequest;
+import com.sentri.backend.dto.request.StoredMyspaceSearchRequest;
 import com.sentri.backend.dto.request.UpsertMyspaceItemRequest;
+import com.sentri.backend.dto.response.BulkMyspaceItemsResponse;
 import com.sentri.backend.dto.response.MyspaceItemResponse;
+import com.sentri.backend.dto.response.MyspaceSearchResponse;
+import com.sentri.backend.service.MyspaceIntelligenceService;
 import com.sentri.backend.service.MyspaceItemService;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
@@ -21,9 +27,14 @@ import java.util.List;
 public class MyspaceItemController {
 
     private final MyspaceItemService myspaceItemService;
+    private final MyspaceIntelligenceService myspaceIntelligenceService;
 
-    public MyspaceItemController(MyspaceItemService myspaceItemService) {
+    public MyspaceItemController(
+            MyspaceItemService myspaceItemService,
+            MyspaceIntelligenceService myspaceIntelligenceService
+    ) {
         this.myspaceItemService = myspaceItemService;
+        this.myspaceIntelligenceService = myspaceIntelligenceService;
     }
 
     @PostMapping
@@ -31,9 +42,29 @@ public class MyspaceItemController {
         return myspaceItemService.upsert(request);
     }
 
+    @PostMapping("/bulk")
+    public BulkMyspaceItemsResponse bulkUpsert(@Valid @RequestBody BulkUpsertMyspaceItemsRequest request) {
+        List<MyspaceItemResponse> items = myspaceItemService.bulkUpsert(request.items());
+        return new BulkMyspaceItemsResponse(items.size(), items);
+    }
+
     @GetMapping
     public List<MyspaceItemResponse> listItems() {
         return myspaceItemService.listItems();
+    }
+
+    @PostMapping("/search")
+    public MyspaceSearchResponse searchStoredItems(@RequestBody(required = false) StoredMyspaceSearchRequest request) {
+        StoredMyspaceSearchRequest safeRequest = request == null
+                ? new StoredMyspaceSearchRequest("", "All", null, null)
+                : request;
+        return myspaceIntelligenceService.search(new MyspaceSearchRequest(
+                safeRequest.query(),
+                safeRequest.selectedSubject(),
+                List.of(),
+                safeRequest.queryEmbedding(),
+                safeRequest.vectorLimit()
+        ));
     }
 
     @GetMapping("/{itemId}")

--- a/backend/src/main/java/com/sentri/backend/dto/request/BulkUpsertMyspaceItemsRequest.java
+++ b/backend/src/main/java/com/sentri/backend/dto/request/BulkUpsertMyspaceItemsRequest.java
@@ -1,0 +1,12 @@
+package com.sentri.backend.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record BulkUpsertMyspaceItemsRequest(
+        @NotEmpty(message = "items are required")
+        List<@Valid UpsertMyspaceItemRequest> items
+) {
+}

--- a/backend/src/main/java/com/sentri/backend/dto/request/StoredMyspaceSearchRequest.java
+++ b/backend/src/main/java/com/sentri/backend/dto/request/StoredMyspaceSearchRequest.java
@@ -1,0 +1,11 @@
+package com.sentri.backend.dto.request;
+
+import java.util.List;
+
+public record StoredMyspaceSearchRequest(
+        String query,
+        String selectedSubject,
+        List<Float> queryEmbedding,
+        Integer vectorLimit
+) {
+}

--- a/backend/src/main/java/com/sentri/backend/dto/response/BulkMyspaceItemsResponse.java
+++ b/backend/src/main/java/com/sentri/backend/dto/response/BulkMyspaceItemsResponse.java
@@ -1,0 +1,9 @@
+package com.sentri.backend.dto.response;
+
+import java.util.List;
+
+public record BulkMyspaceItemsResponse(
+        Integer totalItems,
+        List<MyspaceItemResponse> items
+) {
+}

--- a/backend/src/main/java/com/sentri/backend/service/MyspaceIntelligenceServiceImpl.java
+++ b/backend/src/main/java/com/sentri/backend/service/MyspaceIntelligenceServiceImpl.java
@@ -300,6 +300,11 @@ public class MyspaceIntelligenceServiceImpl implements MyspaceIntelligenceServic
         }
 
         @Override
+        public List<com.sentri.backend.dto.response.MyspaceItemResponse> bulkUpsert(List<com.sentri.backend.dto.request.UpsertMyspaceItemRequest> requests) {
+            return List.of();
+        }
+
+        @Override
         public com.sentri.backend.dto.response.MyspaceItemResponse getItem(String itemId) {
             throw new UnsupportedOperationException("No-op service");
         }

--- a/backend/src/main/java/com/sentri/backend/service/MyspaceItemService.java
+++ b/backend/src/main/java/com/sentri/backend/service/MyspaceItemService.java
@@ -10,6 +10,8 @@ public interface MyspaceItemService {
 
     MyspaceItemResponse upsert(UpsertMyspaceItemRequest request);
 
+    List<MyspaceItemResponse> bulkUpsert(List<UpsertMyspaceItemRequest> requests);
+
     MyspaceItemResponse getItem(String itemId);
 
     List<MyspaceItemResponse> listItems();

--- a/backend/src/main/java/com/sentri/backend/service/MyspaceItemServiceImpl.java
+++ b/backend/src/main/java/com/sentri/backend/service/MyspaceItemServiceImpl.java
@@ -55,6 +55,14 @@ public class MyspaceItemServiceImpl implements MyspaceItemService {
     }
 
     @Override
+    @Transactional
+    public List<MyspaceItemResponse> bulkUpsert(List<UpsertMyspaceItemRequest> requests) {
+        return requests.stream()
+                .map(this::upsert)
+                .toList();
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public MyspaceItemResponse getItem(String itemId) {
         return toResponse(load(itemId));

--- a/backend/src/test/java/com/sentri/backend/controller/MyspaceItemControllerTest.java
+++ b/backend/src/test/java/com/sentri/backend/controller/MyspaceItemControllerTest.java
@@ -1,6 +1,9 @@
 package com.sentri.backend.controller;
 
+import com.sentri.backend.dto.response.BulkMyspaceItemsResponse;
 import com.sentri.backend.dto.response.MyspaceItemResponse;
+import com.sentri.backend.dto.response.MyspaceSearchResponse;
+import com.sentri.backend.service.MyspaceIntelligenceService;
 import com.sentri.backend.service.MyspaceItemService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +32,9 @@ class MyspaceItemControllerTest {
 
     @MockBean
     private MyspaceItemService myspaceItemService;
+
+    @MockBean
+    private MyspaceIntelligenceService myspaceIntelligenceService;
 
     @Test
     void upsertsItem() throws Exception {
@@ -96,5 +102,71 @@ class MyspaceItemControllerTest {
 
         mockMvc.perform(delete("/api/v1/myspace/items/item-1"))
                 .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void bulkUpsertsItems() throws Exception {
+        when(myspaceItemService.bulkUpsert(any())).thenReturn(List.of(
+                new MyspaceItemResponse(
+                        "item-1",
+                        "DBMS notes",
+                        "Normalization summary",
+                        "DBMS",
+                        List.of("dbms"),
+                        "Screenshot",
+                        "Today",
+                        "ocr",
+                        true,
+                        false,
+                        Instant.parse("2026-04-23T00:00:00Z"),
+                        Instant.parse("2026-04-23T00:00:00Z")
+                )
+        ));
+
+        mockMvc.perform(post("/api/v1/myspace/items/bulk")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "items": [
+                                    {
+                                      "id": "item-1",
+                                      "title": "DBMS notes",
+                                      "body": "Normalization summary",
+                                      "subject": "DBMS",
+                                      "tags": ["dbms"],
+                                      "source": "Screenshot",
+                                      "dateLabel": "Today",
+                                      "ocrText": "ocr",
+                                      "pinned": true,
+                                      "featured": false
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalItems").value(1))
+                .andExpect(jsonPath("$.items[0].id").value("item-1"));
+    }
+
+    @Test
+    void searchesStoredItems() throws Exception {
+        when(myspaceIntelligenceService.search(any())).thenReturn(new MyspaceSearchResponse(
+                "math",
+                "All",
+                1,
+                List.of()
+        ));
+
+        mockMvc.perform(post("/api/v1/myspace/items/search")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "query": "math",
+                                  "selectedSubject": "All"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.query").value("math"))
+                .andExpect(jsonPath("$.totalMatches").value(1));
     }
 }

--- a/backend/src/test/java/com/sentri/backend/service/MyspaceIntelligenceServiceTest.java
+++ b/backend/src/test/java/com/sentri/backend/service/MyspaceIntelligenceServiceTest.java
@@ -229,6 +229,11 @@ class MyspaceIntelligenceServiceTest {
             }
 
             @Override
+            public List<com.sentri.backend.dto.response.MyspaceItemResponse> bulkUpsert(List<com.sentri.backend.dto.request.UpsertMyspaceItemRequest> requests) {
+                return List.of();
+            }
+
+            @Override
             public com.sentri.backend.dto.response.MyspaceItemResponse getItem(String itemId) {
                 throw new UnsupportedOperationException();
             }

--- a/backend/src/test/java/com/sentri/backend/service/MyspaceItemServiceTest.java
+++ b/backend/src/test/java/com/sentri/backend/service/MyspaceItemServiceTest.java
@@ -61,4 +61,39 @@ class MyspaceItemServiceTest {
         assertThatThrownBy(() -> myspaceItemService.getItem("item-2"))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
+
+    @Test
+    void bulkUpsertsItems() {
+        List<MyspaceItemResponse> responses = myspaceItemService.bulkUpsert(List.of(
+                new UpsertMyspaceItemRequest(
+                        "item-3",
+                        "CG notes",
+                        "Z buffer",
+                        "CG",
+                        List.of("graphics"),
+                        "Board",
+                        "Today",
+                        "z buffer",
+                        false,
+                        true
+                ),
+                new UpsertMyspaceItemRequest(
+                        "item-4",
+                        "OS notes",
+                        "Paging",
+                        "OS",
+                        List.of("os"),
+                        "Screenshot",
+                        "Today",
+                        "paging",
+                        false,
+                        false
+                )
+        ));
+
+        assertThat(responses).hasSize(2);
+        assertThat(myspaceItemService.listItems())
+                .extracting(MyspaceItemResponse::id)
+                .contains("item-3", "item-4");
+    }
 }


### PR DESCRIPTION
Closes #61

## Summary
- add bulk upsert endpoint for SQL-backed Myspace items
- add SQL-backed search endpoint over persisted Myspace items
- extend service and controller coverage for the new API surface