### PR TITLE
Add graph-backed Myspace relationships

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>pgvector</artifactId>
             <version>0.1.6</version>
         </dependency>
+        <dependency>
+            <groupId>org.neo4j.driver</groupId>
+            <artifactId>neo4j-java-driver</artifactId>
+            <version>5.28.5</version>
+        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>

--- a/backend/src/main/java/com/sentri/backend/SentriBackendApplication.java
+++ b/backend/src/main/java/com/sentri/backend/SentriBackendApplication.java
@@ -1,5 +1,6 @@
 package com.sentri.backend;
 
+import com.sentri.backend.config.MyspaceGraphProperties;
 import com.sentri.backend.config.MyspaceVectorProperties;
 import com.sentri.backend.config.TimetableUploadProperties;
 import org.springframework.boot.SpringApplication;
@@ -9,7 +10,7 @@ import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
 @EnableCaching
-@EnableConfigurationProperties({TimetableUploadProperties.class, MyspaceVectorProperties.class})
+@EnableConfigurationProperties({TimetableUploadProperties.class, MyspaceVectorProperties.class, MyspaceGraphProperties.class})
 public class SentriBackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/sentri/backend/config/MyspaceGraphProperties.java
+++ b/backend/src/main/java/com/sentri/backend/config/MyspaceGraphProperties.java
@@ -1,0 +1,14 @@
+package com.sentri.backend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sentri.myspace.graph")
+public record MyspaceGraphProperties(
+        boolean enabled,
+        String uri,
+        String username,
+        String password,
+        String database,
+        int maxRelatedLimit
+) {
+}

--- a/backend/src/main/java/com/sentri/backend/config/Neo4jDriverConfig.java
+++ b/backend/src/main/java/com/sentri/backend/config/Neo4jDriverConfig.java
@@ -1,0 +1,21 @@
+package com.sentri.backend.config;
+
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Neo4jDriverConfig {
+
+    @Bean(destroyMethod = "close")
+    @ConditionalOnProperty(prefix = "sentri.myspace.graph", name = "enabled", havingValue = "true")
+    Driver neo4jDriver(MyspaceGraphProperties properties) {
+        return GraphDatabase.driver(
+                properties.uri(),
+                AuthTokens.basic(properties.username(), properties.password())
+        );
+    }
+}

--- a/backend/src/main/java/com/sentri/backend/controller/MyspaceGraphController.java
+++ b/backend/src/main/java/com/sentri/backend/controller/MyspaceGraphController.java
@@ -1,0 +1,44 @@
+package com.sentri.backend.controller;
+
+import com.sentri.backend.dto.response.MyspaceGraphRelatedItemsResponse;
+import com.sentri.backend.dto.response.MyspaceGraphSyncResponse;
+import com.sentri.backend.service.MyspaceGraphService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/v1/myspace/graph", produces = MediaType.APPLICATION_JSON_VALUE)
+public class MyspaceGraphController {
+
+    private final MyspaceGraphService myspaceGraphService;
+
+    public MyspaceGraphController(MyspaceGraphService myspaceGraphService) {
+        this.myspaceGraphService = myspaceGraphService;
+    }
+
+    @PostMapping("/sync-all")
+    public MyspaceGraphSyncResponse syncAll() {
+        int synced = myspaceGraphService.syncAll();
+        return new MyspaceGraphSyncResponse(myspaceGraphService.isAvailable(), synced);
+    }
+
+    @PostMapping("/sync/{itemId}")
+    public MyspaceGraphSyncResponse syncItem(@PathVariable String itemId) {
+        int synced = myspaceGraphService.syncItem(itemId);
+        return new MyspaceGraphSyncResponse(myspaceGraphService.isAvailable(), synced);
+    }
+
+    @GetMapping("/{itemId}/related")
+    public MyspaceGraphRelatedItemsResponse relatedItems(
+            @PathVariable String itemId,
+            @RequestParam(name = "limit", required = false) Integer limit
+    ) {
+        var items = myspaceGraphService.relatedItems(itemId, limit);
+        return new MyspaceGraphRelatedItemsResponse(myspaceGraphService.isAvailable(), items.size(), items);
+    }
+}

--- a/backend/src/main/java/com/sentri/backend/dto/response/MyspaceGraphRelatedItemResponse.java
+++ b/backend/src/main/java/com/sentri/backend/dto/response/MyspaceGraphRelatedItemResponse.java
@@ -1,0 +1,12 @@
+package com.sentri.backend.dto.response;
+
+import java.util.List;
+
+public record MyspaceGraphRelatedItemResponse(
+        String itemId,
+        String title,
+        String subject,
+        Integer score,
+        List<String> signals
+) {
+}

--- a/backend/src/main/java/com/sentri/backend/dto/response/MyspaceGraphRelatedItemsResponse.java
+++ b/backend/src/main/java/com/sentri/backend/dto/response/MyspaceGraphRelatedItemsResponse.java
@@ -1,0 +1,10 @@
+package com.sentri.backend.dto.response;
+
+import java.util.List;
+
+public record MyspaceGraphRelatedItemsResponse(
+        Boolean graphAvailable,
+        Integer totalItems,
+        List<MyspaceGraphRelatedItemResponse> items
+) {
+}

--- a/backend/src/main/java/com/sentri/backend/dto/response/MyspaceGraphSyncResponse.java
+++ b/backend/src/main/java/com/sentri/backend/dto/response/MyspaceGraphSyncResponse.java
@@ -1,0 +1,7 @@
+package com.sentri.backend.dto.response;
+
+public record MyspaceGraphSyncResponse(
+        Boolean graphAvailable,
+        Integer syncedItems
+) {
+}

--- a/backend/src/main/java/com/sentri/backend/service/MyspaceGraphService.java
+++ b/backend/src/main/java/com/sentri/backend/service/MyspaceGraphService.java
@@ -1,0 +1,16 @@
+package com.sentri.backend.service;
+
+import com.sentri.backend.dto.response.MyspaceGraphRelatedItemResponse;
+
+import java.util.List;
+
+public interface MyspaceGraphService {
+
+    boolean isAvailable();
+
+    int syncItem(String itemId);
+
+    int syncAll();
+
+    List<MyspaceGraphRelatedItemResponse> relatedItems(String itemId, Integer limit);
+}

--- a/backend/src/main/java/com/sentri/backend/service/MyspaceGraphServiceImpl.java
+++ b/backend/src/main/java/com/sentri/backend/service/MyspaceGraphServiceImpl.java
@@ -1,0 +1,161 @@
+package com.sentri.backend.service;
+
+import com.sentri.backend.config.MyspaceGraphProperties;
+import com.sentri.backend.dto.response.MyspaceGraphRelatedItemResponse;
+import com.sentri.backend.dto.response.MyspaceItemResponse;
+import jakarta.annotation.PostConstruct;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MyspaceGraphServiceImpl implements MyspaceGraphService {
+
+    private final MyspaceItemService myspaceItemService;
+    private final MyspaceGraphProperties properties;
+    private final Driver driver;
+
+    public MyspaceGraphServiceImpl(
+            MyspaceItemService myspaceItemService,
+            MyspaceGraphProperties properties,
+            ObjectProvider<Driver> driverProvider
+    ) {
+        this.myspaceItemService = myspaceItemService;
+        this.properties = properties;
+        this.driver = driverProvider.getIfAvailable();
+    }
+
+    @PostConstruct
+    void initializeGraph() {
+        if (!isAvailable()) {
+            return;
+        }
+
+        try (Session session = openSession()) {
+            session.run("CREATE CONSTRAINT myspace_item_id IF NOT EXISTS FOR (n:MyspaceItem) REQUIRE n.id IS UNIQUE");
+            session.run("CREATE CONSTRAINT myspace_subject_name IF NOT EXISTS FOR (n:Subject) REQUIRE n.name IS UNIQUE");
+            session.run("CREATE CONSTRAINT myspace_tag_name IF NOT EXISTS FOR (n:Tag) REQUIRE n.name IS UNIQUE");
+        }
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return properties.enabled() && driver != null;
+    }
+
+    @Override
+    public int syncItem(String itemId) {
+        if (!isAvailable()) {
+            return 0;
+        }
+        sync(myspaceItemService.getItem(itemId));
+        return 1;
+    }
+
+    @Override
+    public int syncAll() {
+        if (!isAvailable()) {
+            return 0;
+        }
+        List<MyspaceItemResponse> items = myspaceItemService.listItems();
+        items.forEach(this::sync);
+        return items.size();
+    }
+
+    @Override
+    public List<MyspaceGraphRelatedItemResponse> relatedItems(String itemId, Integer limit) {
+        if (!isAvailable()) {
+            return List.of();
+        }
+
+        int safeLimit = limit == null || limit < 1
+                ? properties.maxRelatedLimit()
+                : Math.min(limit, properties.maxRelatedLimit());
+
+        try (Session session = openSession()) {
+            return session.run("""
+                    MATCH (source:MyspaceItem {id: $itemId})
+                    CALL {
+                      WITH source
+                      MATCH (source)-[:IN_SUBJECT]->(:Subject)<-[:IN_SUBJECT]-(related:MyspaceItem)
+                      WHERE related.id <> source.id
+                      RETURN related.id AS itemId, related.title AS title, related.subject AS subject, 2 AS weight, 'subject' AS signal
+                      UNION ALL
+                      WITH source
+                      MATCH (source)-[:HAS_TAG]->(:Tag)<-[:HAS_TAG]-(related:MyspaceItem)
+                      WHERE related.id <> source.id
+                      RETURN related.id AS itemId, related.title AS title, related.subject AS subject, 1 AS weight, 'tag' AS signal
+                    }
+                    WITH itemId, title, subject, sum(weight) AS score, collect(DISTINCT signal) AS signals
+                    RETURN itemId, title, subject, score, signals
+                    ORDER BY score DESC, title ASC
+                    LIMIT $limit
+                    """, Map.of("itemId", itemId, "limit", safeLimit))
+                    .list(record -> new MyspaceGraphRelatedItemResponse(
+                            record.get("itemId").asString(),
+                            record.get("title").asString(),
+                            record.get("subject").asString(),
+                            record.get("score").asInt(),
+                            record.get("signals").asList(value -> value.asString())
+                    ));
+        }
+    }
+
+    private void sync(MyspaceItemResponse item) {
+        try (Session session = openSession()) {
+            session.executeWrite(tx -> {
+                tx.run("""
+                        MERGE (item:MyspaceItem {id: $id})
+                        SET item.title = $title,
+                            item.subject = $subject,
+                            item.source = $source,
+                            item.dateLabel = $dateLabel,
+                            item.pinned = $pinned,
+                            item.featured = $featured
+                        """, itemParameters(item));
+                tx.run("""
+                        MATCH (item:MyspaceItem {id: $id})
+                        OPTIONAL MATCH (item)-[r:HAS_TAG|IN_SUBJECT]->()
+                        DELETE r
+                        """, Map.of("id", item.id()));
+                tx.run("""
+                        MATCH (item:MyspaceItem {id: $id})
+                        MERGE (subject:Subject {name: $subject})
+                        MERGE (item)-[:IN_SUBJECT]->(subject)
+                        """, Map.of("id", item.id(), "subject", item.subject()));
+                for (String tag : item.tags()) {
+                    tx.run("""
+                            MATCH (item:MyspaceItem {id: $id})
+                            MERGE (tag:Tag {name: $tag})
+                            MERGE (item)-[:HAS_TAG]->(tag)
+                            """, Map.of("id", item.id(), "tag", tag));
+                }
+                return null;
+            });
+        }
+    }
+
+    private Map<String, Object> itemParameters(MyspaceItemResponse item) {
+        return Map.of(
+                "id", item.id(),
+                "title", item.title(),
+                "subject", item.subject(),
+                "source", item.source(),
+                "dateLabel", item.dateLabel(),
+                "pinned", item.pinned(),
+                "featured", item.featured()
+        );
+    }
+
+    private Session openSession() {
+        String database = properties.database();
+        return (database == null || database.isBlank())
+                ? driver.session()
+                : driver.session(SessionConfig.forDatabase(database));
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,6 +23,13 @@ server:
 
 sentri:
   myspace:
+    graph:
+      enabled: ${SENTRI_MYSPACE_GRAPH_ENABLED:false}
+      uri: ${SENTRI_MYSPACE_GRAPH_URI:bolt://localhost:7687}
+      username: ${SENTRI_MYSPACE_GRAPH_USERNAME:neo4j}
+      password: ${SENTRI_MYSPACE_GRAPH_PASSWORD:sentri-graph}
+      database: ${SENTRI_MYSPACE_GRAPH_DATABASE:neo4j}
+      max-related-limit: ${SENTRI_MYSPACE_GRAPH_MAX_RELATED_LIMIT:12}
     vector:
       enabled: ${SENTRI_MYSPACE_VECTOR_ENABLED:true}
       dimension: ${SENTRI_MYSPACE_VECTOR_DIMENSION:384}

--- a/backend/src/test/java/com/sentri/backend/controller/MyspaceGraphControllerTest.java
+++ b/backend/src/test/java/com/sentri/backend/controller/MyspaceGraphControllerTest.java
@@ -1,0 +1,52 @@
+package com.sentri.backend.controller;
+
+import com.sentri.backend.dto.response.MyspaceGraphRelatedItemResponse;
+import com.sentri.backend.service.MyspaceGraphService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MyspaceGraphController.class)
+class MyspaceGraphControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MyspaceGraphService myspaceGraphService;
+
+    @Test
+    void syncsAllItems() throws Exception {
+        when(myspaceGraphService.isAvailable()).thenReturn(true);
+        when(myspaceGraphService.syncAll()).thenReturn(4);
+
+        mockMvc.perform(post("/api/v1/myspace/graph/sync-all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.graphAvailable").value(true))
+                .andExpect(jsonPath("$.syncedItems").value(4));
+    }
+
+    @Test
+    void listsRelatedItems() throws Exception {
+        when(myspaceGraphService.isAvailable()).thenReturn(true);
+        when(myspaceGraphService.relatedItems("item-1", 5)).thenReturn(List.of(
+                new MyspaceGraphRelatedItemResponse("item-2", "DBMS notes", "DBMS", 3, List.of("subject", "tag"))
+        ));
+
+        mockMvc.perform(get("/api/v1/myspace/graph/item-1/related").param("limit", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.graphAvailable").value(true))
+                .andExpect(jsonPath("$.totalItems").value(1))
+                .andExpect(jsonPath("$.items[0].itemId").value("item-2"));
+    }
+}

--- a/backend/src/test/java/com/sentri/backend/service/MyspaceGraphServiceTest.java
+++ b/backend/src/test/java/com/sentri/backend/service/MyspaceGraphServiceTest.java
@@ -1,0 +1,145 @@
+package com.sentri.backend.service;
+
+import com.sentri.backend.config.MyspaceGraphProperties;
+import com.sentri.backend.dto.response.MyspaceGraphRelatedItemResponse;
+import com.sentri.backend.dto.response.MyspaceItemResponse;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.TransactionContext;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MyspaceGraphServiceTest {
+
+    @Test
+    void returnsRelatedItemsFromGraphQuery() {
+        Driver driver = mock(Driver.class);
+        Session session = mock(Session.class);
+        Result result = mock(Result.class);
+        Record record = mock(Record.class);
+        Value signals = Values.value(List.of("subject", "tag"));
+
+        when(driver.session(any(SessionConfig.class))).thenReturn(session);
+        when(session.run(anyString(), anyMap())).thenReturn(result);
+        when(result.list(any(Function.class))).thenAnswer(invocation -> {
+            Function<Record, MyspaceGraphRelatedItemResponse> mapper = invocation.getArgument(0);
+            return List.of(mapper.apply(record));
+        });
+        when(record.get("itemId")).thenReturn(Values.value("item-2"));
+        when(record.get("title")).thenReturn(Values.value("DBMS notes"));
+        when(record.get("subject")).thenReturn(Values.value("DBMS"));
+        when(record.get("score")).thenReturn(Values.value(3));
+        when(record.get("signals")).thenReturn(signals);
+
+        MyspaceGraphService service = new MyspaceGraphServiceImpl(
+                new NoOpItemService(),
+                new MyspaceGraphProperties(true, "bolt://localhost:7687", "neo4j", "password", "neo4j", 12),
+                provider(driver)
+        );
+
+        List<MyspaceGraphRelatedItemResponse> relatedItems = service.relatedItems("item-1", 5);
+        assertThat(relatedItems).hasSize(1);
+        assertThat(relatedItems.get(0).itemId()).isEqualTo("item-2");
+        assertThat(relatedItems.get(0).signals()).containsExactly("subject", "tag");
+    }
+
+    @Test
+    void syncsAllPersistedItemsIntoGraph() {
+        Driver driver = mock(Driver.class);
+        Session session = mock(Session.class);
+        TransactionContext tx = mock(TransactionContext.class);
+
+        when(driver.session(any(SessionConfig.class))).thenReturn(session);
+        when(session.executeWrite(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            var callback = (org.neo4j.driver.TransactionCallback<Object>) invocation.getArgument(0);
+            return callback.execute(tx);
+        });
+        when(tx.run(anyString(), anyMap())).thenReturn(mock(Result.class));
+        when(session.run(anyString())).thenReturn(mock(Result.class));
+
+        MyspaceGraphService service = new MyspaceGraphServiceImpl(
+                new FixedItemService(),
+                new MyspaceGraphProperties(true, "bolt://localhost:7687", "neo4j", "password", "neo4j", 12),
+                provider(driver)
+        );
+
+        assertThat(service.syncAll()).isEqualTo(1);
+    }
+
+    private ObjectProvider<Driver> provider(Driver driver) {
+        return new ObjectProvider<>() {
+            @Override
+            public Driver getObject(Object... args) {
+                return driver;
+            }
+
+            @Override
+            public Driver getIfAvailable() {
+                return driver;
+            }
+
+            @Override
+            public Driver getIfUnique() {
+                return driver;
+            }
+
+            @Override
+            public Driver getObject() {
+                return driver;
+            }
+        };
+    }
+
+    private static class NoOpItemService implements MyspaceItemService {
+        @Override
+        public MyspaceItemResponse upsert(com.sentri.backend.dto.request.UpsertMyspaceItemRequest request) { throw new UnsupportedOperationException(); }
+        @Override
+        public List<MyspaceItemResponse> bulkUpsert(List<com.sentri.backend.dto.request.UpsertMyspaceItemRequest> requests) { return List.of(); }
+        @Override
+        public MyspaceItemResponse getItem(String itemId) { throw new UnsupportedOperationException(); }
+        @Override
+        public List<MyspaceItemResponse> listItems() { return List.of(); }
+        @Override
+        public void deleteItem(String itemId) { throw new UnsupportedOperationException(); }
+        @Override
+        public List<com.sentri.backend.dto.request.MyspaceSearchItemRequest> listSearchItems() { return List.of(); }
+    }
+
+    private static final class FixedItemService extends NoOpItemService {
+        @Override
+        public List<MyspaceItemResponse> listItems() {
+            return List.of(new MyspaceItemResponse(
+                    "item-1",
+                    "DBMS notes",
+                    "Normalization",
+                    "DBMS",
+                    List.of("dbms", "sql"),
+                    "Screenshot",
+                    "Today",
+                    "ocr",
+                    true,
+                    false,
+                    Instant.parse("2026-04-26T00:00:00Z"),
+                    Instant.parse("2026-04-26T00:00:00Z")
+            ));
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,19 +21,42 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: sentri-backend
-    depends_on:
-      postgres:
-        condition: service_healthy
     environment:
       SENTRI_DATABASE_URL: jdbc:postgresql://postgres:5432/sentri
       SENTRI_DATABASE_USERNAME: sentri
       SENTRI_DATABASE_PASSWORD: sentri
+      SENTRI_MYSPACE_GRAPH_ENABLED: "true"
+      SENTRI_MYSPACE_GRAPH_URI: bolt://neo4j:7687
+      SENTRI_MYSPACE_GRAPH_USERNAME: neo4j
+      SENTRI_MYSPACE_GRAPH_PASSWORD: sentri-graph
       SENTRI_TIMETABLE_UPLOAD_DIR: /app/data/timetable-uploads
     ports:
       - "8080:8080"
     volumes:
       - sentri-backend-data:/app/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+
+  neo4j:
+    image: neo4j:5
+    container_name: sentri-neo4j
+    environment:
+      NEO4J_AUTH: neo4j/sentri-graph
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    volumes:
+      - sentri-neo4j-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p sentri-graph 'RETURN 1' >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
 
 volumes:
   sentri-postgres-data:
   sentri-backend-data:
+  sentri-neo4j-data:


### PR DESCRIPTION
Closes #62

## Summary
- add optional Neo4j-backed relationship storage for Myspace items
- expose graph sync and related-item REST endpoints
- extend Docker runtime to include a Neo4j container and backend graph configuration