### PR TITLE
Add ML worker CI and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,34 +1,27 @@
 ## Summary
 
-- what changed
-- why it changed
-- what areas are affected
+-
 
 ## Linked Issue
 
-- closes #
+Closes #
 
-## Checklist
+## What Changed
 
-- [ ] I did not push directly to `main`
-- [ ] This branch has small logical commits
-- [ ] I reviewed my own diff before requesting merge
-- [ ] `app` compiles with `npx tsc --noEmit`
-- [ ] `backend` tests pass with `mvn test`
-- [ ] Any architecture-impacting changes are documented
+-
 
-## Screens / API Notes
+## Verification
 
-- frontend changes:
-- backend changes:
-- AI / reasoning changes:
-- ML worker changes:
+- [ ] `cd app && npx tsc --noEmit`
+- [ ] `cd backend && mvn test`
+- [ ] `cd ml-worker && pytest`
+- [ ] Other:
 
-## Review Focus
+## Review Notes
 
-- what should reviewers check most closely?
+- Areas to check:
+- Data, API, or ML worker contract changes:
 
-## Risks
+## Risks And Follow-Up
 
-- known gaps:
-- follow-up work:
+-

--- a/.github/workflows/ml-worker.yml
+++ b/.github/workflows/ml-worker.yml
@@ -1,0 +1,46 @@
+name: ML Worker
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ml-worker.yml"
+      - "ml-worker/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ml-worker.yml"
+      - "ml-worker/**"
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            ml-worker/pyproject.toml
+            ml-worker/requirements*.txt
+
+      - name: Install worker
+        working-directory: ml-worker
+        run: python -m pip install -e ".[dev]"
+
+      - name: Run tests
+        working-directory: ml-worker
+        run: pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Avoid mixing UI redesign, backend behavior, and infra changes in a single commit
 
 - Use the issue templates for bug reports and feature requests.
 - A PR should close or clearly reference one tracked issue unless the change is emergency-only.
+- Use `.github/pull_request_template.md` for every PR. Keep the summary short, link the issue, and list the verification commands that actually ran.
 - The PR description should call out the exact frontend, backend, or ML worker surface touched.
 - If a change is intentionally partial, note the follow-up issue in the PR body.
 
@@ -48,6 +49,7 @@ Before merging a PR, check:
 - architecture impact is documented
 - API contracts are explicit
 - tests pass
+- ML worker changes include `cd ml-worker && pytest` output or a clear reason it was not run
 - mobile build still compiles
 - no dead demo-only code path was introduced silently
 - performance-sensitive reads and renders are considered

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The app should stay simple and cheap to run:
 
 - Node.js 16+ for frontend
 - Java 17+ for backend
-- Python 3.8+ for ML worker
+- Python 3.11+ for ML worker
 
 ### Frontend
 
@@ -76,8 +76,11 @@ mvn spring-boot:run
 
 ```bash
 cd ml-worker
-python3 -m unittest discover -s tests
+python -m pip install -e ".[dev]"
+pytest
 ```
+
+The same worker test command runs in GitHub Actions for pull requests that touch `ml-worker` or the worker workflow.
 
 ## Notes
 

--- a/ml-worker/README.md
+++ b/ml-worker/README.md
@@ -1,6 +1,6 @@
 # Sentri OCR Worker
 
-[![CI](https://github.com/yourusername/sentri/workflows/CI/badge.svg)](https://github.com/yourusername/sentri/actions)
+[![ML Worker](https://github.com/SahilKumar75/sentri/actions/workflows/ml-worker.yml/badge.svg)](https://github.com/SahilKumar75/sentri/actions/workflows/ml-worker.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -9,13 +9,13 @@ Zero-budget OCR and timetable parsing worker for Sentri. Designed to sit behind 
 
 ## Features
 
-- 🔍 **OCR Processing** - Extract text from timetable images using Tesseract
-- 📊 **Intelligent Parsing** - Convert raw OCR text into structured timetable entries
-- 🎯 **High Accuracy** - Deterministic parsing logic with fuzzy matching
-- 🔧 **Configurable** - Tuning profiles for customization
-- 📈 **Metrics** - Built-in performance monitoring and evaluation
-- 🐳 **Docker Ready** - Containerized deployment with Docker Compose
-- ✅ **Well Tested** - Comprehensive test suite with high coverage
+- OCR processing with Tesseract when the binary is available
+- Deterministic parsing from raw OCR text and cell-like table input
+- Fuzzy matching for common timetable OCR errors
+- Tuning profiles for subject, faculty, and parser behavior
+- Metrics and fixture evaluation for parser quality checks
+- Docker support for repeatable local runs
+- Pytest coverage for parser, worker, cache, validation, and utility code
 
 ## Quick Start
 
@@ -117,7 +117,7 @@ pre-commit install
 
 ```bash
 # Run all tests
-make test
+pytest
 
 # Run with coverage
 make test-cov
@@ -125,6 +125,8 @@ make test-cov
 # Run specific test
 pytest tests/test_parser.py -v
 ```
+
+GitHub Actions runs `pytest` on Python 3.11 and 3.12 whenever a pull request changes worker files.
 
 ### Code Quality
 


### PR DESCRIPTION
## Summary

- Adds a dedicated ML worker GitHub Actions workflow.
- Replaces the default PR template with concise review and verification prompts.
- Updates repository and worker docs for the current pytest workflow.

## Linked Issue

Closes #79
Closes #83

## What Changed

- Added `.github/workflows/ml-worker.yml` for Python 3.11 and 3.12 worker tests.
- Updated `.github/pull_request_template.md` to require issue links, verification, review notes, and risks.
- Aligned README and contributing guidance with the worker test command.

## Verification

- [ ] `cd app && npx tsc --noEmit`
- [ ] `cd backend && mvn test`
- [x] `cd ml-worker && pytest` attempted; collection currently stops on the pre-existing `OperationMetrics` import mismatch in `tests/test_metrics.py`.
- [x] `git diff --check`

## Review Notes

- Areas to check: workflow trigger paths, Python matrix, PR template wording.
- Data, API, or ML worker contract changes: none.

## Risks And Follow-Up

- #80 and #82 cover the pipeline changes and the test-suite import repair.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python version requirement to 3.11+ for ML Worker.
  * Revised ML Worker test instructions to use pytest for testing.
  * Updated README with current testing procedures and CI badge.

* **Chores**
  * Added automated ML Worker testing workflow.
  * Updated pull request template and contribution guidelines for clearer submission requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SahilKumar75/sentri/pull/84)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->