### PR TITLE
Harden ML pipeline validation and tests

### DIFF
--- a/ml-worker/CHANGELOG.md
+++ b/ml-worker/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Pipeline preprocessing for malformed option payloads.
+- Low-confidence issue reporting through `quality_options.min_extraction_confidence`.
+- Fixture regression tests for backend-ready worker output.
+- Operation-level metrics compatibility for existing metrics tests.
+
 ## [0.2.0] - 2026-04-30
 
 ### Added

--- a/ml-worker/README.md
+++ b/ml-worker/README.md
@@ -185,6 +185,18 @@ Customize parsing behavior with tuning profiles:
 }
 ```
 
+### Quality Options
+
+```json
+{
+  "quality_options": {
+    "min_extraction_confidence": 0.75
+  }
+}
+```
+
+When `extractionConfidence` is below `min_extraction_confidence`, the worker still returns parsed entries and adds a `low_confidence` issue to `metadata.sourceNotes`.
+
 ## Architecture
 
 ```

--- a/ml-worker/src/sentri_worker/lib/metrics.py
+++ b/ml-worker/src/sentri_worker/lib/metrics.py
@@ -9,6 +9,41 @@ from typing import Any
 
 
 @dataclass
+class OperationMetrics:
+    """Timing and status for one named operation."""
+
+    operation_name: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    start_time: float = field(default_factory=time.perf_counter)
+    end_time: float | None = None
+    success: bool = True
+    error_message: str | None = None
+
+    @property
+    def duration(self) -> float | None:
+        """Return elapsed seconds after the operation is completed."""
+        if self.end_time is None:
+            return None
+        return self.end_time - self.start_time
+
+    def complete(self, success: bool = True, error_message: str | None = None) -> None:
+        """Mark the operation as completed."""
+        self.end_time = time.perf_counter()
+        self.success = success
+        self.error_message = error_message
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert operation metrics to a serializable dictionary."""
+        return {
+            "operation": self.operation_name,
+            "success": self.success,
+            "error_message": self.error_message,
+            "duration": round(self.duration, 4) if self.duration is not None else None,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass
 class OCRMetrics:
     """Metrics for OCR operations."""
 
@@ -131,7 +166,39 @@ class MetricsCollector:
     def __init__(self) -> None:
         self.ocr_metrics = OCRMetrics()
         self.parsing_metrics = ParsingMetrics()
+        self.operations: list[OperationMetrics] = []
+        self.counters: dict[str, int] = defaultdict(int)
+        self.gauges: dict[str, float] = {}
         self.start_time = time.time()
+
+    def start_operation(self, operation_name: str, metadata: dict[str, Any] | None = None) -> OperationMetrics:
+        """Start and store operation-level metrics."""
+        metric = OperationMetrics(operation_name=operation_name, metadata=metadata or {})
+        self.operations.append(metric)
+        return metric
+
+    def increment_counter(self, name: str, amount: int = 1) -> None:
+        """Increment a named counter."""
+        self.counters[name] += amount
+
+    def set_gauge(self, name: str, value: float) -> None:
+        """Set a named gauge value."""
+        self.gauges[name] = value
+
+    def get_summary(self) -> dict[str, Any]:
+        """Return operation-level summary metrics."""
+        total_operations = len(self.operations)
+        successful_operations = sum(1 for operation in self.operations if operation.success)
+        failed_operations = sum(1 for operation in self.operations if not operation.success)
+        success_rate = successful_operations / total_operations if total_operations else 0.0
+        return {
+            "total_operations": total_operations,
+            "successful_operations": successful_operations,
+            "failed_operations": failed_operations,
+            "success_rate": round(success_rate, 4),
+            "counters": dict(self.counters),
+            "gauges": dict(self.gauges),
+        }
 
     def get_uptime(self) -> float:
         """Get uptime in seconds."""
@@ -143,12 +210,16 @@ class MetricsCollector:
             "uptime_seconds": round(self.get_uptime(), 2),
             "ocr": self.ocr_metrics.to_dict(),
             "parsing": self.parsing_metrics.to_dict(),
+            "operations": self.get_summary(),
         }
 
     def reset(self) -> None:
         """Reset all metrics."""
         self.ocr_metrics = OCRMetrics()
         self.parsing_metrics = ParsingMetrics()
+        self.operations = []
+        self.counters = defaultdict(int)
+        self.gauges = {}
         self.start_time = time.time()
 
 

--- a/ml-worker/src/sentri_worker/pipeline.py
+++ b/ml-worker/src/sentri_worker/pipeline.py
@@ -13,6 +13,7 @@ class SentriWorker:
         self.ocr_service = ocr_service or OCRService()
 
     def process(self, payload: dict[str, Any]) -> dict[str, Any]:
+        payload, pipeline_warnings = self._prepare_payload(payload)
         source = {
             "source_name": payload.get("source_name"),
             "image_path": payload.get("image_path"),
@@ -22,7 +23,7 @@ class SentriWorker:
 
         cells, payload_warnings = self._parse_cells(payload.get("cells"))
         tuning_profile = load_tuning_profile(payload)
-        parsing_options = payload.get("parsing_options") if isinstance(payload.get("parsing_options"), dict) else {}
+        parsing_options = payload["parsing_options"]
         fallback_to_text_schedule = parsing_options.get("fallback_to_text_schedule")
         if not isinstance(fallback_to_text_schedule, bool):
             fallback_to_text_schedule = True
@@ -36,27 +37,17 @@ class SentriWorker:
         )
         result.source["ocr"] = ocr_result.to_dict()
         if ocr_result.warnings:
-            result.issues.extend(
-                [
-                    ParseIssue(code="ocr_warning", message=warning)
-                    for warning in ocr_result.warnings
-                ]
-            )
+            result.issues.extend([ParseIssue(code="ocr_warning", message=warning) for warning in ocr_result.warnings])
         if payload_warnings:
+            result.issues.extend([ParseIssue(code="payload_warning", message=warning) for warning in payload_warnings])
+        if pipeline_warnings:
             result.issues.extend(
-                [
-                    ParseIssue(code="payload_warning", message=warning)
-                    for warning in payload_warnings
-                ]
+                [ParseIssue(code="pipeline_warning", message=warning) for warning in pipeline_warnings]
             )
 
         extraction_confidence = self._coerce_float(payload.get("extraction_confidence"))
         if extraction_confidence is None:
-            confidences = [
-                float(cell.confidence)
-                for cell in cells
-                if cell.confidence is not None
-            ]
+            confidences = [float(cell.confidence) for cell in cells if cell.confidence is not None]
             cell_confidence = round(sum(confidences) / len(confidences), 4) if confidences else None
             extraction_confidence = self._blend_confidence(
                 cell_confidence,
@@ -64,10 +55,42 @@ class SentriWorker:
                 payload.get("confidence_weights"),
             )
         extraction_confidence = self._clamp_confidence(extraction_confidence)
+        threshold, threshold_warning = self._parse_confidence_threshold(payload["quality_options"])
+        if threshold_warning:
+            result.issues.append(ParseIssue(code="pipeline_warning", message=threshold_warning))
+        if extraction_confidence is not None and threshold is not None and extraction_confidence < threshold:
+            result.issues.append(
+                ParseIssue(
+                    code="low_confidence",
+                    message=f"Extraction confidence {extraction_confidence:.2f} is below threshold {threshold:.2f}.",
+                )
+            )
 
-        return result.to_backend_import_dict(
-            extraction_confidence=extraction_confidence
-        )
+        return result.to_backend_import_dict(extraction_confidence=extraction_confidence)
+
+    def _prepare_payload(self, payload: Any) -> tuple[dict[str, Any], list[str]]:
+        warnings: list[str] = []
+        if not isinstance(payload, dict):
+            warnings.append("Replaced payload because it is not an object.")
+            payload = {}
+        else:
+            payload = dict(payload)
+
+        for field in ("parsing_options", "quality_options"):
+            value = payload.get(field)
+            if value is None:
+                payload[field] = {}
+                continue
+            if not isinstance(value, dict):
+                warnings.append(f"Ignored {field} because it is not an object.")
+                payload[field] = {}
+
+        confidence_weights = payload.get("confidence_weights")
+        if confidence_weights is not None and not isinstance(confidence_weights, dict):
+            warnings.append("Ignored confidence_weights because it is not an object.")
+            payload["confidence_weights"] = None
+
+        return payload, warnings
 
     def _parse_cells(self, cells_payload: Any) -> tuple[list[OCRCell], list[str]]:
         if cells_payload is None:
@@ -124,6 +147,14 @@ class SentriWorker:
         if value is None:
             return None
         return max(0.0, min(1.0, value))
+
+    def _parse_confidence_threshold(self, quality_options: dict[str, Any]) -> tuple[float | None, str | None]:
+        if "min_extraction_confidence" not in quality_options:
+            return None, None
+        threshold = self._coerce_float(quality_options.get("min_extraction_confidence"))
+        if threshold is None:
+            return None, "Ignored min_extraction_confidence because it is not numeric."
+        return self._clamp_confidence(threshold), None
 
     def _blend_confidence(
         self,

--- a/ml-worker/tests/fixtures/pipeline_malformed_payload.json
+++ b/ml-worker/tests/fixtures/pipeline_malformed_payload.json
@@ -1,0 +1,15 @@
+{
+  "source_name": "fixture-malformed.png",
+  "ocr_text": "Class: SE IT-B\nMON\n08:45-09:45 DBMS",
+  "extraction_confidence": 0.42,
+  "parsing_options": "fallback",
+  "confidence_weights": "balanced",
+  "quality_options": {
+    "min_extraction_confidence": 0.75
+  },
+  "cells": {
+    "row": 1,
+    "col": 1,
+    "text": "DBMS"
+  }
+}

--- a/ml-worker/tests/fixtures/pipeline_valid_payload.json
+++ b/ml-worker/tests/fixtures/pipeline_valid_payload.json
@@ -1,0 +1,31 @@
+{
+  "source_name": "fixture-valid.png",
+  "ocr_text": "Class: SE IT-B\nAcademic Year - 2025-26 - SEM II\nVenue: LH 20",
+  "extraction_confidence": 0.81,
+  "quality_options": {
+    "min_extraction_confidence": 0.7
+  },
+  "cells": [
+    {
+      "row": 0,
+      "col": 0,
+      "text": "TIME/DAY"
+    },
+    {
+      "row": 0,
+      "col": 1,
+      "text": "8.45-9.45"
+    },
+    {
+      "row": 1,
+      "col": 0,
+      "text": "MON"
+    },
+    {
+      "row": 1,
+      "col": 1,
+      "text": "DBMS\n(MA)\nLab-III",
+      "confidence": 0.82
+    }
+  ]
+}

--- a/ml-worker/tests/test_pipeline_regression.py
+++ b/ml-worker/tests/test_pipeline_regression.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sentri_worker.pipeline import SentriWorker
+
+
+def _source_notes(result: dict[str, Any]) -> str:
+    return result["metadata"].get("sourceNotes") or ""
+
+
+def test_pipeline_fixture_keeps_backend_contract(load_fixture) -> None:
+    result = SentriWorker().process(load_fixture("pipeline_valid_payload.json"))
+
+    assert result["metadata"]["yearLabel"] == "SE"
+    assert result["metadata"]["branchLabel"] == "IT"
+    assert result["metadata"]["sourceImageName"] == "fixture-valid.png"
+    assert result["extractionConfidence"] == 0.81
+    assert result["entries"][0]["dayOfWeek"] == "MON"
+    assert result["entries"][0]["subjectName"] == "DBMS"
+    assert "issue:low_confidence" not in _source_notes(result)
+
+
+def test_pipeline_fixture_reports_malformed_payload_and_low_confidence(load_fixture) -> None:
+    result = SentriWorker().process(load_fixture("pipeline_malformed_payload.json"))
+    source_notes = _source_notes(result)
+
+    assert result["extractionConfidence"] == 0.42
+    assert result["entries"][0]["dayOfWeek"] == "MON"
+    assert "issue:payload_warning:Ignored cells payload because it is not a list." in source_notes
+    assert "issue:pipeline_warning:Ignored parsing_options because it is not an object." in source_notes
+    assert "issue:pipeline_warning:Ignored confidence_weights because it is not an object." in source_notes
+    assert "issue:low_confidence:Extraction confidence 0.42 is below threshold 0.75." in source_notes
+
+
+def test_pipeline_ignores_invalid_confidence_threshold() -> None:
+    result = SentriWorker().process(
+        {
+            "ocr_text": "Class: SE IT-B\nMON 08:45-09:45 DBMS",
+            "extraction_confidence": 0.8,
+            "quality_options": {"min_extraction_confidence": "high"},
+        }
+    )
+
+    assert "issue:pipeline_warning:Ignored min_extraction_confidence because it is not numeric." in _source_notes(
+        result
+    )


### PR DESCRIPTION
## Summary

- Adds preprocessing for malformed ML worker option payloads.
- Adds low-confidence issue reporting without blocking parsed output.
- Restores operation-level metrics support and adds fixture regression tests.

## Linked Issue

Closes #80
Closes #81
Closes #82

## What Changed

- Normalizes `parsing_options`, `confidence_weights`, and `quality_options` before OCR and parsing.
- Adds `quality_options.min_extraction_confidence` support with a `low_confidence` issue in `metadata.sourceNotes`.
- Adds fixture-based regression coverage for valid and malformed worker payloads.
- Adds operation metrics methods expected by the existing metrics tests.
- Documents quality options in the worker README and changelog.

## Verification

- [ ] `cd app && npx tsc --noEmit`
- [ ] `cd backend && mvn test`
- [x] `cd ml-worker && python3 -m pytest` passed, 126 tests.
- [x] `git diff --check`

## Review Notes

- Areas to check: pipeline warning messages, confidence threshold behavior, fixture assertions.
- Data, API, or ML worker contract changes: `metadata.sourceNotes` can now include `pipeline_warning` and `low_confidence` issue codes.

## Risks And Follow-Up

- The threshold is advisory only; imports still return parsed entries for backend review.
