### PR TITLE
Align PR template with JavaScript app

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Closes #
 
 ## Verification
 
-- [ ] `cd app && npx tsc --noEmit`
+- [ ] `cd app && npx expo export --platform web --output-dir /tmp/sentri-web-export`
 - [ ] `cd backend && mvn test`
 - [ ] `cd ml-worker && pytest`
 - [ ] Other:

--- a/docs/myspace-indexing-pipeline.md
+++ b/docs/myspace-indexing-pipeline.md
@@ -21,7 +21,7 @@ flowchart LR
 
 ## Core Data Model
 
-Myspace currently indexes the `SavedItem` shape from [app/src/features/myspace/models.ts](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/models.ts):
+Myspace currently indexes the `SavedItem` shape used by [app/src/features/myspace/seed-data.js](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/seed-data.js) and the retrieval engine:
 
 - `id`
 - `title`
@@ -40,7 +40,7 @@ These fields are sufficient for the current retrieval logic because ranking is d
 
 ## Capture Ingestion
 
-Capture actions are defined in [app/src/features/myspace/seed-data.ts](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/seed-data.ts) as:
+Capture actions are defined in [app/src/features/myspace/seed-data.js](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/seed-data.js) as:
 
 - `image`
 - `link`
@@ -48,7 +48,7 @@ Capture actions are defined in [app/src/features/myspace/seed-data.ts](/Users/sa
 - `file`
 - `screenshot`
 
-The capture flow is implemented in [app/src/features/myspace/capture-builder.ts](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/capture-builder.ts).
+The capture flow is implemented in [app/src/features/myspace/capture-builder.js](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/capture-builder.js).
 
 ### Capture Steps
 
@@ -74,7 +74,7 @@ The capture flow is implemented in [app/src/features/myspace/capture-builder.ts]
 
 Myspace state is currently persisted with `usePersistedState` under:
 
-- [app/src/lib/persistent-keys.ts](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/lib/persistent-keys.ts)
+- [app/src/lib/persistent-keys.js](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/lib/persistent-keys.js)
   - `sentri.myspace.items`
   - `sentri.myspace.recentSearches`
 
@@ -86,7 +86,7 @@ This means the device currently owns:
 
 ## Retrieval Engine
 
-The retrieval engine lives in [app/src/features/myspace/retrieval-engine.ts](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/retrieval-engine.ts).
+The retrieval engine lives in [app/src/features/myspace/retrieval-engine.js](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/retrieval-engine.js).
 
 ### Match Reasons
 
@@ -145,7 +145,7 @@ This is why newly captured items and pinned notes remain discoverable without re
 
 ## Search Suggestions
 
-Suggestion logic lives in [app/src/features/myspace/search-history.ts](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/search-history.ts).
+Suggestion logic lives in [app/src/features/myspace/search-history.js](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/features/myspace/search-history.js).
 
 The suggestion list is built from:
 
@@ -158,7 +158,7 @@ This is intentionally lightweight. It improves recall without requiring a backen
 
 ## UI Contract
 
-The screen integration is currently in [app/src/screens/MyspaceScreen.tsx](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/screens/MyspaceScreen.tsx).
+The screen integration is currently in [app/src/screens/MyspaceScreen.jsx](/Users/sahilkumarsingh/Desktop/SENTRI/app/src/screens/MyspaceScreen.jsx).
 
 The UI depends on three retrieval guarantees:
 

--- a/docs/sentri-plan.md
+++ b/docs/sentri-plan.md
@@ -50,7 +50,7 @@ Those things either cost money, add risk, or both.
 
 ## Mobile
 
-- `React Native + Expo + TypeScript`
+- `React Native + Expo + JavaScript`
 - one app for iOS and Android
 - `expo-sqlite` for local cache and offline data
 - `Expo Router` for navigation

--- a/docs/system-design-lld.md
+++ b/docs/system-design-lld.md
@@ -8,7 +8,7 @@ This document translates the high-level architecture into concrete modules, resp
 
 #### App Shell
 
-- `App.tsx`
+- `App.jsx`
   - restores session token
   - restores last active tab
   - resolves deep links
@@ -22,8 +22,8 @@ Target design:
 
 #### Shared Storage Layer
 
-- `src/lib/auth-storage.ts`
-- `src/lib/device-store.ts`
+- `src/lib/auth-storage.js`
+- `src/lib/device-store.js`
 
 Target design:
 


### PR DESCRIPTION
## Summary
- Update the default PR checklist to use the Expo web export check instead of the removed TypeScript check.
- Refresh Markdown references from removed TypeScript files to the current JavaScript and JSX files.
- Keep repository docs aligned with the JavaScript Expo app migration.

## Testing
- rg -n "tsc|TypeScript|typescript|tsx|\.ts" README.md CONTRIBUTING.md docs .github --glob '!app/node_modules/**'
- git diff --check

Closes #90