### PR TITLE
Tune Myspace aliases and Hangout empty state

### DIFF
--- a/app/src/features/myspace/retrieval-engine.js
+++ b/app/src/features/myspace/retrieval-engine.js
@@ -1,19 +1,24 @@
 
 
 const SUBJECT_ALIASES = {
-  DBMS: ['database', 'db', 'normalization', 'sql'],
-  'P&S': ['math', 'statistics', 'probability', 'permutation', 'combination'],
-  OS: ['operating systems', 'paging', 'cpu', 'memory'],
-  CG: ['graphics', 'z buffer', 'transformation', 'rendering'],
-  PM: ['project', 'sprint', 'timeline'],
+  DBMS: ['database', 'db', 'normalization', 'sql', 'normal form', 'normal forms'],
+  'P&S': ['math', 'statistics', 'probability', 'permutation', 'combination', 'stats'],
+  OS: ['operating systems', 'operating system', 'paging', 'cpu', 'memory', 'process'],
+  CG: ['graphics', 'computer graphics', 'z buffer', 'transformation', 'rendering'],
+  PM: ['project', 'sprint', 'timeline', 'project management', 'submission'],
   Placement: ['interview', 'aptitude', 'company', 'job'],
 };
 
 const CONTEXT_ALIASES = {
+  assignment: ['homework', 'submission', 'task', 'practical file', 'writeup'],
   blackboard: ['board', 'chalkboard', 'class board'],
-  screenshot: ['screen', 'slide', 'capture'],
-  image: ['photo', 'picture'],
-  revision: ['study', 'prep', 'practice'],
+  image: ['photo', 'picture', 'gallery'],
+  lab: ['practical', 'experiment', 'lab manual', 'lab file'],
+  lecture: ['class', 'slides', 'slide', 'session'],
+  notes: ['note', 'study material', 'material', 'handout', 'summary'],
+  revision: ['study', 'prep', 'practice', 'exam prep', 'revise'],
+  screenshot: ['screen', 'slide', 'capture', 'screen grab'],
+  timetable: ['schedule', 'routine', 'weekly plan', 'class schedule'],
 };
 
 export function rankMyspaceItems(items, query, subject = 'All') {

--- a/app/src/screens/HangoutScreen.jsx
+++ b/app/src/screens/HangoutScreen.jsx
@@ -506,10 +506,23 @@ export default function HangoutScreen({ onOpenDrawer, avatarLabel, sessionToken,
               </View>
             </Pressable>))}
           {rooms.length === 0 ? (<View style={styles.emptyRooms}>
-              <Text style={styles.emptyRoomsTitle}>No rooms yet</Text>
+              <View style={styles.emptyRoomsIcon}>
+                <Ionicons name="videocam-outline" size={22} color={theme.colors.accentStrong}/>
+              </View>
+              <Text style={styles.emptyRoomsTitle}>No active hangouts</Text>
               <Text style={styles.emptyRoomsBody}>
-                Create the first study room or join one from a Sentri link.
+                Start a study room, paste a room code, or keep this page open while a friend shares a Sentri link.
               </Text>
+              <View style={styles.emptyActionGrid}>
+                <Pressable style={styles.emptyActionButton} onPress={() => void handleCreateRoom()} disabled={loadingAction !== 'idle'}>
+                  <Ionicons name="add-circle" size={16} color="#FFFFFF"/>
+                  <Text style={styles.emptyActionText}>Create room</Text>
+                </Pressable>
+                <Pressable style={[styles.emptyActionButton, styles.emptyActionButtonGhost]} onPress={() => void handleJoinByCode()} disabled={loadingAction !== 'idle'}>
+                  <Ionicons name="enter-outline" size={16} color={theme.colors.accentStrong}/>
+                  <Text style={[styles.emptyActionText, styles.emptyActionTextGhost]}>Join by code</Text>
+                </Pressable>
+              </View>
             </View>) : null}
         </View>
 
@@ -1134,6 +1147,15 @@ const styles = StyleSheet.create({
         paddingHorizontal: 16,
         paddingVertical: 14,
     },
+    emptyRoomsIcon: {
+        width: 44,
+        height: 44,
+        borderRadius: 16,
+        backgroundColor: theme.colors.accentSoft,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginBottom: 12,
+    },
     emptyRoomsTitle: {
         color: theme.colors.text,
         fontSize: 16,
@@ -1144,6 +1166,36 @@ const styles = StyleSheet.create({
         color: theme.colors.textSoft,
         fontSize: 13,
         lineHeight: 19,
+    },
+    emptyActionGrid: {
+        marginTop: 14,
+        flexDirection: 'row',
+        gap: 10,
+    },
+    emptyActionButton: {
+        flex: 1,
+        minHeight: 44,
+        borderRadius: 16,
+        backgroundColor: theme.colors.accent,
+        borderWidth: 1,
+        borderColor: theme.colors.accent,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        paddingHorizontal: 10,
+    },
+    emptyActionButtonGhost: {
+        backgroundColor: theme.colors.surface,
+        borderColor: theme.colors.line,
+    },
+    emptyActionText: {
+        color: '#FFFFFF',
+        fontSize: 13,
+        fontWeight: '800',
+    },
+    emptyActionTextGhost: {
+        color: theme.colors.accentStrong,
     },
     sectionHeader: {
         flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Expand Myspace retrieval aliases for student search terms around notes, assignments, labs, lectures, screenshots, timetable, and subject shortcuts.
- Replace the Hangout no-room copy with an action-oriented empty state.
- Add direct create/join actions to the empty Hangout panel.

## Testing
- Parsed app/src/features/myspace/retrieval-engine.js and app/src/screens/HangoutScreen.jsx with Babel parser.
- cd app && npx expo export --platform web --output-dir /private/tmp/sentri-resolve-107-108-web
- git diff --check

Closes #107
Closes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced search result relevance through expanded topic and context recognition.
  * Updated empty hangout lobby state with clearer messaging ("No active hangouts") and quick action buttons to create or join rooms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SahilKumar75/sentri/pull/112)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->